### PR TITLE
Fix exception when arbiter is configured but not available

### DIFF
--- a/alignak_module_ws/etc/arbiter/modules/mod-ws.cfg
+++ b/alignak_module_ws/etc/arbiter/modules/mod-ws.cfg
@@ -34,12 +34,14 @@ define module {
     # Alignak arbiter configuration
     # ---
     # Alignak main arbiter interface
+    # Set alignak_host as empty to disable the Alignak arbiter polling
+    # The default is to poll a local Alignak arbiter to check it is alive
     #alignak_host            127.0.0.1
     #alignak_port            7770
 
     # Alignak polling period
-    # Periodically check that the Alignak arbiter is alive
-    #alignak_polling_period              1
+    # Periodically (every 5 seconds) check that the Alignak arbiter is alive
+    #alignak_polling_period              5
 
     # Alignak daemons status refresh period
     # Periodically get the Alignak daemons status

--- a/alignak_module_ws/utils/ws_server.py
+++ b/alignak_module_ws/utils/ws_server.py
@@ -40,7 +40,7 @@ SESSION_KEY = 'alignak_web_services'
 def protect(*args, **kwargs):
     # pylint: disable=unused-argument
     """Check user credentials from HTTP Authorization request header"""
-    logger.debug("Inside protect()...")
+    # logger.debug("Inside protect()...")
 
     authenticated = False
     conditions = cherrypy.request.config.get('auth.require', None)
@@ -256,6 +256,9 @@ class WSInterface(object):
 
         if cherrypy.request and not cherrypy.request.json:
             return {'_status': 'ERR', '_error': 'You must send parameters on this endpoint.'}
+
+        if host_name and cherrypy.request.json.get('name', None) is not None:
+            host_name = cherrypy.request.json.get('name', None)
 
         if not host_name:
             host_name = cherrypy.request.json.get('name', None)

--- a/test/test_module.py
+++ b/test/test_module.py
@@ -359,7 +359,7 @@ class TestModuleWs(AlignakTest):
         self.assert_log_match(
             re.escape("Alignak Arbiter configuration: 127.0.0.1:7770"), 2)
         self.assert_log_match(
-            re.escape("Alignak Arbiter polling period: 1"), 3)
+            re.escape("Alignak Arbiter polling period: 5"), 3)
         self.assert_log_match(
             re.escape("Alignak daemons get status period: 10"), 4)
         self.assert_log_match(
@@ -408,7 +408,7 @@ class TestModuleWs(AlignakTest):
         self.assert_log_match(
             re.escape("Alignak Arbiter configuration: my_host:80"), 2)
         self.assert_log_match(
-            re.escape("Alignak Arbiter polling period: 1"), 3)
+            re.escape("Alignak Arbiter polling period: 5"), 3)
         self.assert_log_match(
             re.escape("Alignak daemons get status period: 10"), 4)
         self.assert_log_match(

--- a/test/test_module_host.py
+++ b/test/test_module_host.py
@@ -194,7 +194,7 @@ class TestModuleWs(AlignakTest):
         resp = response.json()
         print(resp)
 
-        # Allowed GET request on /host
+        # Allowed GET request on /host - forbidden to GET
         response = session.get('http://127.0.0.1:8888/host')
         self.assertEqual(response.status_code, 200)
         result = response.json()
@@ -226,6 +226,16 @@ class TestModuleWs(AlignakTest):
             "name": "test_host",
         }
         response = session.patch('http://127.0.0.1:8888/host', json=data, headers=headers)
+        self.assertEqual(response.status_code, 200)
+        result = response.json()
+        self.assertEqual(result, {u'_status': u'OK', u'_result': [u'test_host is alive :)']})
+
+        # Host name in the POSTed data takes precedence over URI
+        headers = {'Content-Type': 'application/json'}
+        data = {
+            "name": "test_host",
+        }
+        response = session.patch('http://127.0.0.1:8888/host/other_host', json=data, headers=headers)
         self.assertEqual(response.status_code, 200)
         result = response.json()
         self.assertEqual(result, {u'_status': u'OK', u'_result': [u'test_host is alive :)']})


### PR DESCRIPTION
Clean some configuration parameters
Host name in the data takes precedence over the URI