### PR TITLE
Closes #36: host endpoint gives some feedback

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,6 @@ after_success:
   # to get coverage data with relative paths and not absolute we have to
   # execute coveralls from the base directory of the project,
   # so we need to move the .coverage file here :
-  mv test/.coverage . && coveralls --rcfile=test/.coveragerc -v
+  mv test/.coverage . && coveralls --rcfile=test/.coveragerc
   # mv test/.coverage . && coveralls -v
 

--- a/alignak_module_ws/ws.py
+++ b/alignak_module_ws/ws.py
@@ -298,7 +298,7 @@ class AlignakWebServices(BaseModule):
                 continue
 
             try:
-                int(data[field])
+                int(data[field], 16)
             except TypeError:
                 post_data[field] = data[field]
                 continue

--- a/alignak_module_ws/ws.py
+++ b/alignak_module_ws/ws.py
@@ -351,7 +351,8 @@ class AlignakWebServices(BaseModule):
         """
         host = None
 
-        ws_result = {'_status': 'OK', '_result': ['%s is alive :)' % host_name], '_issues': []}
+        ws_result = {'_status': 'OK', '_result': ['%s is alive :)' % host_name],
+                     '_issues': [], '_feedback': {}}
         try:
             if not self.backend_available:
                 self.backend_available = self.getBackendAvailability()
@@ -387,7 +388,7 @@ class AlignakWebServices(BaseModule):
 
                 # Get the newly created host
                 ws_result['_result'].append("Requested host '%s' created." % host_name)
-                host = self.backend.get('/host/%s' % result['_id'])
+                host = self.backend.get('/'.join(['host', result['_id']]))
                 logger.debug("Get host, got: %s", host)
             else:
                 host = result['_items'][0]
@@ -492,6 +493,7 @@ class AlignakWebServices(BaseModule):
         if data['services']:
             if update is None:
                 update = False
+            ws_result['_feedback']['services'] = {}
             for service_id in data['services']:
                 service = data['services'][service_id]
                 service_name = service['name']
@@ -501,6 +503,9 @@ class AlignakWebServices(BaseModule):
                     ws_result['_result'].extend(result['_result'])
                 if '_issues' in result:
                     ws_result['_issues'].extend(result['_issues'])
+                else:
+                    if '_feedback' in result:
+                        ws_result['_feedback']['services'][service_id] = result['_feedback']
 
         # If no update requested
         if update is None:
@@ -508,6 +513,22 @@ class AlignakWebServices(BaseModule):
             if len(ws_result['_issues']):
                 ws_result['_status'] = 'ERR'
                 return ws_result
+
+            host = self.backend.get('/'.join(['host', host['_id']]))
+            ws_result['_feedback'].update({
+                'alias': host['alias'],
+                'notes': host['notes'],
+                'location': host['location'],
+                'active_checks_enabled': host['active_checks_enabled'],
+                'max_check_attempts': host['max_check_attempts'],
+                'check_interval': host['check_interval'],
+                'retry_interval': host['retry_interval'],
+                'passive_checks_enabled': host['passive_checks_enabled'],
+                'check_freshness': host['check_freshness'],
+                'freshness_state': host['freshness_state'],
+                'freshness_threshold': host['freshness_threshold'],
+                '_overall_state_id': host['_overall_state_id']
+            })
 
             ws_result.pop('_issues')
             return ws_result
@@ -519,6 +540,22 @@ class AlignakWebServices(BaseModule):
             if len(ws_result['_issues']):
                 ws_result['_status'] = 'ERR'
                 return ws_result
+
+            host = self.backend.get('/'.join(['host', host['_id']]))
+            ws_result['_feedback'].update({
+                'alias': host['alias'],
+                'notes': host['notes'],
+                'location': host['location'],
+                'active_checks_enabled': host['active_checks_enabled'],
+                'max_check_attempts': host['max_check_attempts'],
+                'check_interval': host['check_interval'],
+                'retry_interval': host['retry_interval'],
+                'passive_checks_enabled': host['passive_checks_enabled'],
+                'check_freshness': host['check_freshness'],
+                'freshness_state': host['freshness_state'],
+                'freshness_threshold': host['freshness_threshold'],
+                '_overall_state_id': host['_overall_state_id']
+            })
 
             ws_result.pop('_issues')
             return ws_result
@@ -537,6 +574,22 @@ class AlignakWebServices(BaseModule):
             if patch_result['_status'] != 'OK':
                 logger.warning("Host patch, got a problem: %s", result)
                 return ('ERR', patch_result['_issues'])
+
+            host = self.backend.get('/'.join(['host', host['_id']]))
+            ws_result['_feedback'].update({
+                'alias': host['alias'],
+                'notes': host['notes'],
+                'location': host['location'],
+                'active_checks_enabled': host['active_checks_enabled'],
+                'max_check_attempts': host['max_check_attempts'],
+                'check_interval': host['check_interval'],
+                'retry_interval': host['retry_interval'],
+                'passive_checks_enabled': host['passive_checks_enabled'],
+                'check_freshness': host['check_freshness'],
+                'freshness_state': host['freshness_state'],
+                'freshness_threshold': host['freshness_threshold'],
+                '_overall_state_id': host['_overall_state_id']
+            })
         except BackendException as exp:
             logger.warning("Alignak backend is currently not available.")
             logger.warning("Exception: %s", exp)
@@ -609,7 +662,7 @@ class AlignakWebServices(BaseModule):
                 # Get the newly created service
                 ws_result['_result'].append("Requested service '%s/%s' created."
                                             % (host['name'], service_name))
-                service = self.backend.get('/service/%s' % result['_id'])
+                service = self.backend.get('/'.join(['service', result['_id']]))
                 logger.info("Get service, got: %s", service)
             else:
                 service = result['_items'][0]
@@ -720,6 +773,21 @@ class AlignakWebServices(BaseModule):
                 ws_result['_status'] = 'ERR'
                 return ws_result
 
+            service = self.backend.get('/'.join(['service', service['_id']]))
+            ws_result['_feedback'] = {
+                'alias': service['alias'],
+                'notes': service['notes'],
+                'active_checks_enabled': service['active_checks_enabled'],
+                'max_check_attempts': service['max_check_attempts'],
+                'check_interval': service['check_interval'],
+                'retry_interval': service['retry_interval'],
+                'passive_checks_enabled': service['passive_checks_enabled'],
+                'check_freshness': service['check_freshness'],
+                'freshness_state': service['freshness_state'],
+                'freshness_threshold': service['freshness_threshold'],
+                '_overall_state_id': service['_overall_state_id']
+            }
+
             ws_result.pop('_issues')
             return ws_result
 
@@ -731,6 +799,21 @@ class AlignakWebServices(BaseModule):
             if len(ws_result['_issues']):
                 ws_result['_status'] = 'ERR'
                 return ws_result
+
+            service = self.backend.get('/'.join(['service', service['_id']]))
+            ws_result['_feedback'] = {
+                'alias': service['alias'],
+                'notes': service['notes'],
+                'active_checks_enabled': service['active_checks_enabled'],
+                'max_check_attempts': service['max_check_attempts'],
+                'check_interval': service['check_interval'],
+                'retry_interval': service['retry_interval'],
+                'passive_checks_enabled': service['passive_checks_enabled'],
+                'check_freshness': service['check_freshness'],
+                'freshness_state': service['freshness_state'],
+                'freshness_threshold': service['freshness_threshold'],
+                '_overall_state_id': service['_overall_state_id']
+            }
 
             ws_result.pop('_issues')
             return ws_result
@@ -751,6 +834,22 @@ class AlignakWebServices(BaseModule):
             if patch_result['_status'] != 'OK':
                 logger.warning("Service patch, got a problem: %s", result)
                 return ('ERR', patch_result['_issues'])
+
+            service = self.backend.get('/'.join(['service', service['_id']]))
+            ws_result['_feedback'] = {
+                'alias': service['alias'],
+                'notes': service['notes'],
+                'active_checks_enabled': service['active_checks_enabled'],
+                'max_check_attempts': service['max_check_attempts'],
+                'check_interval': service['check_interval'],
+                'retry_interval': service['retry_interval'],
+                'passive_checks_enabled': service['passive_checks_enabled'],
+                'check_freshness': service['check_freshness'],
+                'freshness_state': service['freshness_state'],
+                'freshness_threshold': service['freshness_threshold'],
+                '_overall_state_id': service['_overall_state_id']
+            }
+
         except BackendException as exp:
             logger.warning("Alignak backend is currently not available.")
             logger.warning("Exception: %s", exp)

--- a/alignak_module_ws/ws.py
+++ b/alignak_module_ws/ws.py
@@ -392,7 +392,7 @@ class AlignakWebServices(BaseModule):
                 logger.debug("Get host, got: %s", host)
             else:
                 host = result['_items'][0]
-        except BackendException as exp:
+        except BackendException as exp:  # pragma: no cover, should not happen
             logger.warning("Alignak backend exception, updateHost.")
             logger.warning("Exception: %s", exp)
             logger.warning("Exception response: %s", exp.response)
@@ -590,7 +590,7 @@ class AlignakWebServices(BaseModule):
                 'freshness_threshold': host['freshness_threshold'],
                 '_overall_state_id': host['_overall_state_id']
             })
-        except BackendException as exp:
+        except BackendException as exp:  # pragma: no cover, should not happen
             logger.warning("Alignak backend is currently not available.")
             logger.warning("Exception: %s", exp)
             self.backend_available = False
@@ -666,7 +666,7 @@ class AlignakWebServices(BaseModule):
                 logger.info("Get service, got: %s", service)
             else:
                 service = result['_items'][0]
-        except BackendException as exp:
+        except BackendException as exp:  # pragma: no cover, should not happen
             logger.warning("Alignak backend exception, updateService.")
             logger.warning("Exception: %s", exp)
             logger.warning("Exception response: %s", exp.response)
@@ -850,7 +850,7 @@ class AlignakWebServices(BaseModule):
                 '_overall_state_id': service['_overall_state_id']
             }
 
-        except BackendException as exp:
+        except BackendException as exp:  # pragma: no cover, should not happen
             logger.warning("Alignak backend is currently not available.")
             logger.warning("Exception: %s", exp)
             self.backend_available = False
@@ -918,7 +918,7 @@ class AlignakWebServices(BaseModule):
             if post_result['_status'] != 'OK':
                 logger.warning("history post, got a problem: %s", result)
                 result['_issues'] = post_result['_issues']
-        except BackendException as exp:
+        except BackendException as exp:  # pragma: no cover, should not happen
             logger.warning("Alignak backend is currently not available.")
             logger.warning("Exception: %s", exp)
             logger.warning("Response: %s", exp.response)
@@ -1028,7 +1028,7 @@ class AlignakWebServices(BaseModule):
             if self.backend.login(username, password):
                 self.token = self.backend.token
                 logger.debug("Logged-in to the backend, token: %s", self.token)
-        except BackendException as exp:
+        except BackendException as exp:  # pragma: no cover, should not happen
             logger.warning("Alignak backend is currently not available.")
             logger.warning("Exception: %s", exp)
             logger.warning("Response: %s", exp.response)
@@ -1054,7 +1054,7 @@ class AlignakWebServices(BaseModule):
             result = self.backend.get('/realm', {'where': json.dumps({'name': 'All'})})
             logger.debug("Backend availability, got: %s", result)
             self.backend_available = True
-        except BackendException as exp:
+        except BackendException as exp:  # pragma: no cover, should not happen
             logger.warning("Alignak backend is currently not available.")
             logger.warning("Exception: %s", exp)
             logger.warning("Response: %s", exp.response)
@@ -1099,7 +1099,7 @@ class AlignakWebServices(BaseModule):
 
             logger.warning("history request, got a problem: %s", result)
             return result
-        except BackendException as exp:
+        except BackendException as exp:  # pragma: no cover, should not happen
             logger.warning("Alignak backend is currently not available.")
             logger.warning("Exception: %s", exp)
             logger.warning("Response: %s", exp.response)

--- a/test/test_module_host.py
+++ b/test/test_module_host.py
@@ -220,6 +220,7 @@ class TestModuleWs(AlignakTest):
         result = response.json()
         self.assertEqual(result, {u'_status': u'ERR',
                                   u'_result': [u'test_host is alive :)'],
+                                  u'_feedback': {},
                                   u'_issues': [u"Requested host 'test_host' does not exist"]})
 
         # Host name may be the last part of the URI
@@ -229,7 +230,25 @@ class TestModuleWs(AlignakTest):
         response = session.patch('http://127.0.0.1:8888/host/test_host_0', json=data, headers=headers)
         self.assertEqual(response.status_code, 200)
         result = response.json()
-        self.assertEqual(result, {u'_status': u'OK', u'_result': [u'test_host_0 is alive :)']})
+        self.assertEqual(result, {
+            u'_status': u'OK',
+            u'_result': [u'test_host_0 is alive :)'],
+            u'_feedback': {
+                u'_overall_state_id': 3,
+                u'active_checks_enabled': True,
+                u'alias': u'up_0',
+                u'check_freshness': False,
+                u'check_interval': 1,
+                u'freshness_state': u'x',
+                u'freshness_threshold': -1,
+                u'location': {u'coordinates': [46.60611, 1.87528],
+                              u'type': u'Point'},
+                u'max_check_attempts': 3,
+                u'notes': u'',
+                u'passive_checks_enabled': True,
+                u'retry_interval': 1
+            }
+        })
 
         # Host name may be in the POSTed data
         data = {
@@ -238,7 +257,25 @@ class TestModuleWs(AlignakTest):
         response = session.patch('http://127.0.0.1:8888/host', json=data, headers=headers)
         self.assertEqual(response.status_code, 200)
         result = response.json()
-        self.assertEqual(result, {u'_status': u'OK', u'_result': [u'test_host_0 is alive :)']})
+        self.assertEqual(result, {
+            u'_status': u'OK',
+            u'_result': [u'test_host_0 is alive :)'],
+            u'_feedback': {
+                u'_overall_state_id': 3,
+                u'active_checks_enabled': True,
+                u'alias': u'up_0',
+                u'check_freshness': False,
+                u'check_interval': 1,
+                u'freshness_state': u'x',
+                u'freshness_threshold': -1,
+                u'location': {u'coordinates': [46.60611, 1.87528],
+                              u'type': u'Point'},
+                u'max_check_attempts': 3,
+                u'notes': u'',
+                u'passive_checks_enabled': True,
+                u'retry_interval': 1
+            }
+        })
 
         # Host name in the POSTed data takes precedence over URI
         data = {
@@ -247,7 +284,25 @@ class TestModuleWs(AlignakTest):
         response = session.patch('http://127.0.0.1:8888/host/other_host', json=data, headers=headers)
         self.assertEqual(response.status_code, 200)
         result = response.json()
-        self.assertEqual(result, {u'_status': u'OK', u'_result': [u'test_host_0 is alive :)']})
+        self.assertEqual(result, {
+            u'_status': u'OK',
+            u'_result': [u'test_host_0 is alive :)'],
+            u'_feedback': {
+                u'_overall_state_id': 3,
+                u'active_checks_enabled': True,
+                u'alias': u'up_0',
+                u'check_freshness': False,
+                u'check_interval': 1,
+                u'freshness_state': u'x',
+                u'freshness_threshold': -1,
+                u'location': {u'coordinates': [46.60611, 1.87528],
+                              u'type': u'Point'},
+                u'max_check_attempts': 3,
+                u'notes': u'',
+                u'passive_checks_enabled': True,
+                u'retry_interval': 1
+            }
+        })
 
         # Host name must be somewhere !
         headers = {'Content-Type': 'application/json'}
@@ -270,7 +325,25 @@ class TestModuleWs(AlignakTest):
         response = session.patch('http://127.0.0.1:8888/host', json=data, headers=headers)
         self.assertEqual(response.status_code, 200)
         result = response.json()
-        self.assertEqual(result, {u'_status': u'OK', u'_result': [u'test_host_0 is alive :)']})
+        self.assertEqual(result, {
+            u'_status': u'OK',
+            u'_result': [u'test_host_0 is alive :)'],
+            u'_feedback': {
+                u'_overall_state_id': 3,
+                u'active_checks_enabled': True,
+                u'alias': u'up_0',
+                u'check_freshness': False,
+                u'check_interval': 1,
+                u'freshness_state': u'x',
+                u'freshness_threshold': -1,
+                u'location': {u'coordinates': [46.60611, 1.87528],
+                              u'type': u'Point'},
+                u'max_check_attempts': 3,
+                u'notes': u'',
+                u'passive_checks_enabled': True,
+                u'retry_interval': 1
+            }
+        })
 
         # Update host livestate (heartbeat / host is alive): missing state in the livestate
         headers = {'Content-Type': 'application/json'}
@@ -289,6 +362,7 @@ class TestModuleWs(AlignakTest):
         self.assertEqual(result, {u'_status': u'ERR',
                                   u'_result': [u'test_host_0 is alive :)',
                                                u"Host 'test_host_0' unchanged."],
+                                  u'_feedback': {},
                                   u'_issues': [u'Missing state in the livestate.']})
 
         # Update host livestate (heartbeat / host is alive): livestate must have an accepted state
@@ -309,6 +383,7 @@ class TestModuleWs(AlignakTest):
         self.assertEqual(result, {u'_status': u'ERR',
                                   u'_result': [u'test_host_0 is alive :)',
                                                u"Host 'test_host_0' unchanged."],
+                                  u'_feedback': {},
                                   u'_issues': [u"Host state must be UP, DOWN or UNREACHABLE, "
                                                u"and not ''."]})
 
@@ -327,11 +402,28 @@ class TestModuleWs(AlignakTest):
         response = session.patch('http://127.0.0.1:8888/host', json=data, headers=headers)
         self.assertEqual(response.status_code, 200)
         result = response.json()
-        self.assertEqual(result, {u'_status': u'OK',
-                                  u'_result': [u'test_host_0 is alive :)',
-                                               u"PROCESS_HOST_CHECK_RESULT;test_host_0;0;"
-                                               u"Output...|'counter'=1\nLong output...",
-                                               u"Host 'test_host_0' unchanged."]})
+        self.assertEqual(result, {
+            u'_status': u'OK',
+            u'_result': [u'test_host_0 is alive :)',
+                         u"PROCESS_HOST_CHECK_RESULT;test_host_0;0;"
+                         u"Output...|'counter'=1\nLong output...",
+                         u"Host 'test_host_0' unchanged."],
+            u'_feedback': {
+                u'_overall_state_id': 3,
+                u'active_checks_enabled': True,
+                u'alias': u'up_0',
+                u'check_freshness': False,
+                u'check_interval': 1,
+                u'freshness_state': u'x',
+                u'freshness_threshold': -1,
+                u'location': {u'coordinates': [46.60611, 1.87528],
+                              u'type': u'Point'},
+                u'max_check_attempts': 3,
+                u'notes': u'',
+                u'passive_checks_enabled': True,
+                u'retry_interval': 1
+            }
+        })
 
         # Update host livestate (heartbeat / host is alive): livestate
         headers = {'Content-Type': 'application/json'}
@@ -348,11 +440,28 @@ class TestModuleWs(AlignakTest):
         response = session.patch('http://127.0.0.1:8888/host', json=data, headers=headers)
         self.assertEqual(response.status_code, 200)
         result = response.json()
-        self.assertEqual(result, {u'_status': u'OK',
-                                  u'_result': [u'test_host_0 is alive :)',
-                                               u"PROCESS_HOST_CHECK_RESULT;test_host_0;2;"
-                                               u"Output...|'counter'=1\nLong output...",
-                                               u"Host 'test_host_0' unchanged."]})
+        self.assertEqual(result, {
+            u'_status': u'OK',
+            u'_result': [u'test_host_0 is alive :)',
+                         u"PROCESS_HOST_CHECK_RESULT;test_host_0;2;"
+                         u"Output...|'counter'=1\nLong output...",
+                         u"Host 'test_host_0' unchanged."],
+            u'_feedback': {
+                u'_overall_state_id': 3,
+                u'active_checks_enabled': True,
+                u'alias': u'up_0',
+                u'check_freshness': False,
+                u'check_interval': 1,
+                u'freshness_state': u'x',
+                u'freshness_threshold': -1,
+                u'location': {u'coordinates': [46.60611, 1.87528],
+                              u'type': u'Point'},
+                u'max_check_attempts': 3,
+                u'notes': u'',
+                u'passive_checks_enabled': True,
+                u'retry_interval': 1
+            }
+        })
 
         # Update host services livestate
         headers = {'Content-Type': 'application/json'}
@@ -409,7 +518,63 @@ class TestModuleWs(AlignakTest):
                 u"PROCESS_SERVICE_CHECK_RESULT;test_host_0;test_ok_1;1;Output...|'counter'=1\nLong output...",
                 u"Service 'test_host_0/test_ok_1' unchanged.",
                 u"Host 'test_host_0' unchanged."
-            ]
+            ],
+            u'_feedback': {
+                u'_overall_state_id': 3,
+                u'active_checks_enabled': True,
+                u'alias': u'up_0',
+                u'check_freshness': False,
+                u'check_interval': 1,
+                u'freshness_state': u'x',
+                u'freshness_threshold': -1,
+                u'location': {u'coordinates': [46.60611, 1.87528],
+                              u'type': u'Point'},
+                u'max_check_attempts': 3,
+                u'notes': u'',
+                u'passive_checks_enabled': True,
+                u'retry_interval': 1,
+                u'services': {
+                    u'test_service': {
+                        u'_overall_state_id': 3,
+                        u'active_checks_enabled': True,
+                        u'alias': u'',
+                        u'check_freshness': False,
+                        u'check_interval': 1,
+                        u'freshness_state': u'x',
+                        u'freshness_threshold': -1,
+                        u'max_check_attempts': 2,
+                        u'notes': u'just a notes string',
+                        u'passive_checks_enabled': True,
+                        u'retry_interval': 1
+                    },
+                    u'test_service2': {
+                        u'_overall_state_id': 3,
+                        u'active_checks_enabled': True,
+                        u'alias': u'',
+                        u'check_freshness': False,
+                        u'check_interval': 1,
+                        u'freshness_state': u'x',
+                        u'freshness_threshold': -1,
+                        u'max_check_attempts': 2,
+                        u'notes': u'just a notes string',
+                        u'passive_checks_enabled': True,
+                        u'retry_interval': 1
+                    },
+                    u'test_service3': {
+                        u'_overall_state_id': 3,
+                        u'active_checks_enabled': True,
+                        u'alias': u'',
+                        u'check_freshness': False,
+                        u'check_interval': 1,
+                        u'freshness_state': u'x',
+                        u'freshness_threshold': -1,
+                        u'max_check_attempts': 2,
+                        u'notes': u'just a notes string',
+                        u'passive_checks_enabled': True,
+                        u'retry_interval': 1
+                    }
+                }
+            }
         })
 
         # Logout
@@ -519,6 +684,7 @@ class TestModuleWs(AlignakTest):
         result = response.json()
         self.assertEqual(result, {u'_status': u'ERR',
                                   u'_result': [u'test_host is alive :)'],
+                                  u'_feedback': {},
                                   u'_issues': [u"Requested host 'test_host' does not exist"]})
 
         # Host name may be the last part of the URI
@@ -529,7 +695,25 @@ class TestModuleWs(AlignakTest):
         response = session.patch('http://127.0.0.1:8888/host/test_host_0', json=data, headers=headers)
         self.assertEqual(response.status_code, 200)
         result = response.json()
-        self.assertEqual(result, {u'_status': u'OK', u'_result': [u'test_host_0 is alive :)']})
+        self.assertEqual(result, {
+            u'_status': u'OK',
+            u'_result': [u'test_host_0 is alive :)'],
+            u'_feedback': {
+                u'_overall_state_id': 3,
+                u'active_checks_enabled': False,
+                u'alias': u'up_0',
+                u'check_freshness': False,
+                u'check_interval': 1,
+                u'freshness_state': u'x',
+                u'freshness_threshold': -1,
+                u'location': {u'coordinates': [46.60611, 1.87528],
+                              u'type': u'Point'},
+                u'max_check_attempts': 3,
+                u'notes': u'',
+                u'passive_checks_enabled': True,
+                u'retry_interval': 1
+            }
+        })
 
         # Host name may be in the POSTed data
         headers = {'Content-Type': 'application/json'}
@@ -539,7 +723,25 @@ class TestModuleWs(AlignakTest):
         response = session.patch('http://127.0.0.1:8888/host', json=data, headers=headers)
         self.assertEqual(response.status_code, 200)
         result = response.json()
-        self.assertEqual(result, {u'_status': u'OK', u'_result': [u'test_host_0 is alive :)']})
+        self.assertEqual(result, {
+            u'_status': u'OK',
+            u'_result': [u'test_host_0 is alive :)'],
+            u'_feedback': {
+                u'_overall_state_id': 3,
+                u'active_checks_enabled': False,
+                u'alias': u'up_0',
+                u'check_freshness': False,
+                u'check_interval': 1,
+                u'freshness_state': u'x',
+                u'freshness_threshold': -1,
+                u'location': {u'coordinates': [46.60611, 1.87528],
+                              u'type': u'Point'},
+                u'max_check_attempts': 3,
+                u'notes': u'',
+                u'passive_checks_enabled': True,
+                u'retry_interval': 1
+            }
+        })
 
         # Host name in the POSTed data takes precedence over URI
         headers = {'Content-Type': 'application/json'}
@@ -549,7 +751,25 @@ class TestModuleWs(AlignakTest):
         response = session.patch('http://127.0.0.1:8888/host/other_host', json=data, headers=headers)
         self.assertEqual(response.status_code, 200)
         result = response.json()
-        self.assertEqual(result, {u'_status': u'OK', u'_result': [u'test_host_0 is alive :)']})
+        self.assertEqual(result, {
+            u'_status': u'OK',
+            u'_result': [u'test_host_0 is alive :)'],
+            u'_feedback': {
+                u'_overall_state_id': 3,
+                u'active_checks_enabled': False,
+                u'alias': u'up_0',
+                u'check_freshness': False,
+                u'check_interval': 1,
+                u'freshness_state': u'x',
+                u'freshness_threshold': -1,
+                u'location': {u'coordinates': [46.60611, 1.87528],
+                              u'type': u'Point'},
+                u'max_check_attempts': 3,
+                u'notes': u'',
+                u'passive_checks_enabled': True,
+                u'retry_interval': 1
+            }
+        })
 
         # Host name must be somewhere !
         headers = {'Content-Type': 'application/json'}
@@ -572,7 +792,25 @@ class TestModuleWs(AlignakTest):
         response = session.patch('http://127.0.0.1:8888/host', json=data, headers=headers)
         self.assertEqual(response.status_code, 200)
         result = response.json()
-        self.assertEqual(result, {u'_status': u'OK', u'_result': [u'test_host_0 is alive :)']})
+        self.assertEqual(result, {
+            u'_status': u'OK',
+            u'_result': [u'test_host_0 is alive :)'],
+            u'_feedback': {
+                u'_overall_state_id': 3,
+                u'active_checks_enabled': False,
+                u'alias': u'up_0',
+                u'check_freshness': False,
+                u'check_interval': 1,
+                u'freshness_state': u'x',
+                u'freshness_threshold': -1,
+                u'location': {u'coordinates': [46.60611, 1.87528],
+                              u'type': u'Point'},
+                u'max_check_attempts': 3,
+                u'notes': u'',
+                u'passive_checks_enabled': True,
+                u'retry_interval': 1
+            }
+        })
 
         # Update host livestate (heartbeat / host is alive): missing state in the livestate
         headers = {'Content-Type': 'application/json'}
@@ -588,10 +826,12 @@ class TestModuleWs(AlignakTest):
         response = session.patch('http://127.0.0.1:8888/host', json=data, headers=headers)
         self.assertEqual(response.status_code, 200)
         result = response.json()
-        self.assertEqual(result, {u'_status': u'ERR',
-                                  u'_result': [u'test_host_0 is alive :)',
-                                               u"Host 'test_host_0' unchanged."],
-                                  u'_issues': [u'Missing state in the livestate.']})
+        self.assertEqual(result, {
+            u'_status': u'ERR',
+            u'_result': [u'test_host_0 is alive :)', u"Host 'test_host_0' unchanged."],
+            u'_feedback': {},
+            u'_issues': [u'Missing state in the livestate.']
+        })
 
         # Update host livestate (heartbeat / host is alive): livestate must have an accepted state
         headers = {'Content-Type': 'application/json'}
@@ -608,11 +848,11 @@ class TestModuleWs(AlignakTest):
         response = session.patch('http://127.0.0.1:8888/host', json=data, headers=headers)
         self.assertEqual(response.status_code, 200)
         result = response.json()
-        self.assertEqual(result, {u'_status': u'ERR',
-                                  u'_result': [u'test_host_0 is alive :)',
-                                               u"Host 'test_host_0' unchanged."],
-                                  u'_issues': [u"Host state must be UP, DOWN or UNREACHABLE, "
-                                               u"and not ''."]})
+        self.assertEqual(result, {
+            u'_status': u'ERR',
+            u'_result': [u'test_host_0 is alive :)', u"Host 'test_host_0' unchanged."],
+            u'_feedback': {},
+            u'_issues': [u"Host state must be UP, DOWN or UNREACHABLE, and not ''."]})
 
         # Update host livestate (heartbeat / host is alive): livestate must have an accepted state
         headers = {'Content-Type': 'application/json'}
@@ -629,11 +869,11 @@ class TestModuleWs(AlignakTest):
         response = session.patch('http://127.0.0.1:8888/host', json=data, headers=headers)
         self.assertEqual(response.status_code, 200)
         result = response.json()
-        self.assertEqual(result, {u'_status': u'ERR',
-                                  u'_result': [u'test_host_0 is alive :)',
-                                               u"Host 'test_host_0' unchanged."],
-                                  u'_issues': [u"Host state must be UP, DOWN or UNREACHABLE, "
-                                               u"and not 'XXX'."]})
+        self.assertEqual(result, {
+            u'_status': u'ERR',
+            u'_result': [u'test_host_0 is alive :)', u"Host 'test_host_0' unchanged."],
+            u'_feedback': {},
+            u'_issues': [u"Host state must be UP, DOWN or UNREACHABLE, and not 'XXX'."]})
 
         # Update host livestate (heartbeat / host is alive): livestate
         headers = {'Content-Type': 'application/json'}
@@ -650,12 +890,28 @@ class TestModuleWs(AlignakTest):
         response = session.patch('http://127.0.0.1:8888/host', json=data, headers=headers)
         self.assertEqual(response.status_code, 200)
         result = response.json()
-        self.assertEqual(result, {u'_status': u'OK',
-                                  u'_result': [u'test_host_0 is alive :)',
-                                               u"[%d] PROCESS_HOST_CHECK_RESULT;test_host_0;0;"
-                                               u"Output...|'counter'=1\nLong output..."
-                                               % time.time(),
-                                               u"Host 'test_host_0' unchanged."]})
+        self.assertEqual(result, {
+            u'_status': u'OK',
+            u'_result': [u'test_host_0 is alive :)',
+                         u"[%d] PROCESS_HOST_CHECK_RESULT;test_host_0;0;"
+                         u"Output...|'counter'=1\nLong output..." % time.time(),
+                         u"Host 'test_host_0' unchanged."],
+            u'_feedback': {
+                u'_overall_state_id': 3,
+                u'active_checks_enabled': False,
+                u'alias': u'up_0',
+                u'check_freshness': False,
+                u'check_interval': 1,
+                u'freshness_state': u'x',
+                u'freshness_threshold': -1,
+                u'location': {u'coordinates': [46.60611, 1.87528],
+                              u'type': u'Point'},
+                u'max_check_attempts': 3,
+                u'notes': u'',
+                u'passive_checks_enabled': True,
+                u'retry_interval': 1
+            }
+        })
 
         # Update host livestate (heartbeat / host is alive): livestate
         headers = {'Content-Type': 'application/json'}
@@ -672,12 +928,28 @@ class TestModuleWs(AlignakTest):
         response = session.patch('http://127.0.0.1:8888/host', json=data, headers=headers)
         self.assertEqual(response.status_code, 200)
         result = response.json()
-        self.assertEqual(result, {u'_status': u'OK',
-                                  u'_result': [u'test_host_0 is alive :)',
-                                               u"[%d] PROCESS_HOST_CHECK_RESULT;test_host_0;2;"
-                                               u"Output...|'counter'=1\nLong output..."
-                                               % time.time(),
-                                               u"Host 'test_host_0' unchanged."]})
+        self.assertEqual(result, {
+            u'_status': u'OK',
+            u'_result': [u'test_host_0 is alive :)',
+                         u"[%d] PROCESS_HOST_CHECK_RESULT;test_host_0;2;"
+                         u"Output...|'counter'=1\nLong output..." % time.time(),
+                         u"Host 'test_host_0' unchanged."],
+            u'_feedback': {
+                u'_overall_state_id': 3,
+                u'active_checks_enabled': False,
+                u'alias': u'up_0',
+                u'check_freshness': False,
+                u'check_interval': 1,
+                u'freshness_state': u'x',
+                u'freshness_threshold': -1,
+                u'location': {u'coordinates': [46.60611, 1.87528],
+                              u'type': u'Point'},
+                u'max_check_attempts': 3,
+                u'notes': u'',
+                u'passive_checks_enabled': True,
+                u'retry_interval': 1
+            }
+        })
 
         # Update host services livestate
         headers = {'Content-Type': 'application/json'}
@@ -734,7 +1006,63 @@ class TestModuleWs(AlignakTest):
                 u"[%d] PROCESS_SERVICE_CHECK_RESULT;test_host_0;test_ok_1;1;Output...|'counter'=1\nLong output..." % now,
                 u"Service 'test_host_0/test_ok_1' unchanged.",
                 u"Host 'test_host_0' unchanged."
-            ]
+            ],
+            u'_feedback': {
+                u'_overall_state_id': 3,
+                u'active_checks_enabled': False,
+                u'alias': u'up_0',
+                u'check_freshness': False,
+                u'check_interval': 1,
+                u'freshness_state': u'x',
+                u'freshness_threshold': -1,
+                u'location': {u'coordinates': [46.60611, 1.87528],
+                              u'type': u'Point'},
+                u'max_check_attempts': 3,
+                u'notes': u'',
+                u'passive_checks_enabled': True,
+                u'retry_interval': 1,
+                u'services': {
+                    u'test_service': {
+                        u'_overall_state_id': 3,
+                        u'active_checks_enabled': True,
+                        u'alias': u'',
+                        u'check_freshness': False,
+                        u'check_interval': 1,
+                        u'freshness_state': u'x',
+                        u'freshness_threshold': -1,
+                        u'max_check_attempts': 2,
+                        u'notes': u'just a notes string',
+                        u'passive_checks_enabled': True,
+                        u'retry_interval': 1
+                    },
+                    u'test_service2': {
+                        u'_overall_state_id': 3,
+                        u'active_checks_enabled': False,
+                        u'alias': u'',
+                        u'check_freshness': False,
+                        u'check_interval': 1,
+                        u'freshness_state': u'x',
+                        u'freshness_threshold': -1,
+                        u'max_check_attempts': 2,
+                        u'notes': u'just a notes string',
+                        u'passive_checks_enabled': False,
+                        u'retry_interval': 1
+                    },
+                    u'test_service3': {
+                        u'_overall_state_id': 3,
+                        u'active_checks_enabled': True,
+                        u'alias': u'',
+                        u'check_freshness': False,
+                        u'check_interval': 1,
+                        u'freshness_state': u'x',
+                        u'freshness_threshold': -1,
+                        u'max_check_attempts': 2,
+                        u'notes': u'just a notes string',
+                        u'passive_checks_enabled': False,
+                        u'retry_interval': 1
+                    }
+                }
+            }
         })
 
         # Logout
@@ -846,7 +1174,25 @@ class TestModuleWs(AlignakTest):
         response = session.patch('http://127.0.0.1:8888/host', json=data, headers=headers)
         self.assertEqual(response.status_code, 200)
         result = response.json()
-        self.assertEqual(result, {u'_status': u'OK', u'_result': [u'test_host_0 is alive :)']})
+        self.assertEqual(result, {
+            u'_status': u'OK',
+            u'_result': [u'test_host_0 is alive :)'],
+            u'_feedback': {
+                u'_overall_state_id': 3,
+                u'active_checks_enabled': False,
+                u'alias': u'up_0',
+                u'check_freshness': False,
+                u'check_interval': 1,
+                u'freshness_state': u'x',
+                u'freshness_threshold': -1,
+                u'location': {u'coordinates': [46.60611, 1.87528],
+                              u'type': u'Point'},
+                u'max_check_attempts': 3,
+                u'notes': u'',
+                u'passive_checks_enabled': True,
+                u'retry_interval': 1
+            }
+        })
 
         # ----------
         # Host does not exist
@@ -865,6 +1211,7 @@ class TestModuleWs(AlignakTest):
         result = response.json()
         self.assertEqual(result, {u'_status': u'ERR',
                                   u'_result': [u'unknown_host is alive :)'],
+                                  u'_feedback': {},
                                   u'_issues': [u"Requested host 'unknown_host' does not exist"]})
 
 
@@ -883,8 +1230,26 @@ class TestModuleWs(AlignakTest):
         response = session.patch('http://127.0.0.1:8888/host', json=data, headers=headers)
         self.assertEqual(response.status_code, 200)
         result = response.json()
-        self.assertEqual(result, {u'_status': u'OK', u'_result': [u"test_host_0 is alive :)",
-                                                                  u"Host 'test_host_0' updated."]})
+        self.assertEqual(result, {
+            u'_status': u'OK',
+            u'_result': [u"test_host_0 is alive :)",
+                         u"Host 'test_host_0' updated."],
+            u'_feedback': {
+                u'_overall_state_id': 3,
+                u'active_checks_enabled': False,
+                u'alias': u'up_0',
+                u'check_freshness': False,
+                u'check_interval': 1,
+                u'freshness_state': u'x',
+                u'freshness_threshold': -1,
+                u'location': {u'coordinates': [46.60611, 1.87528],
+                              u'type': u'Point'},
+                u'max_check_attempts': 3,
+                u'notes': u'',
+                u'passive_checks_enabled': True,
+                u'retry_interval': 1
+            }
+        })
 
         # Get host data to confirm update
         response = session.get('http://127.0.0.1:5000/host', auth=self.auth,
@@ -914,9 +1279,25 @@ class TestModuleWs(AlignakTest):
         response = session.patch('http://127.0.0.1:8888/host', json=data, headers=headers)
         self.assertEqual(response.status_code, 200)
         result = response.json()
-        self.assertEqual(result, {u'_status': u'OK',
-                                  u'_result': [u'test_host_0 is alive :)',
-                                               u"Host 'test_host_0' unchanged."]})
+        self.assertEqual(result, {
+            u'_status': u'OK',
+            u'_result': [u'test_host_0 is alive :)', u"Host 'test_host_0' unchanged."],
+            u'_feedback': {
+                u'_overall_state_id': 3,
+                u'active_checks_enabled': False,
+                u'alias': u'up_0',
+                u'check_freshness': False,
+                u'check_interval': 1,
+                u'freshness_state': u'x',
+                u'freshness_threshold': -1,
+                u'location': {u'coordinates': [46.60611, 1.87528],
+                              u'type': u'Point'},
+                u'max_check_attempts': 3,
+                u'notes': u'',
+                u'passive_checks_enabled': True,
+                u'retry_interval': 1
+            }
+        })
 
         # Get host data to confirm there was not update
         response = session.get('http://127.0.0.1:5000/host', auth=self.auth,
@@ -947,8 +1328,25 @@ class TestModuleWs(AlignakTest):
         response = session.patch('http://127.0.0.1:8888/host', json=data, headers=headers)
         self.assertEqual(response.status_code, 200)
         result = response.json()
-        self.assertEqual(result, {u'_status': u'OK', u'_result': [u'test_host_0 is alive :)',
-                                                                  u"Host 'test_host_0' updated."]})
+        self.assertEqual(result, {
+            u'_status': u'OK',
+            u'_result': [u'test_host_0 is alive :)', u"Host 'test_host_0' updated."],
+            u'_feedback': {
+                u'_overall_state_id': 3,
+                u'active_checks_enabled': False,
+                u'alias': u'up_0',
+                u'check_freshness': False,
+                u'check_interval': 1,
+                u'freshness_state': u'x',
+                u'freshness_threshold': -1,
+                u'location': {u'coordinates': [46.60611, 1.87528],
+                              u'type': u'Point'},
+                u'max_check_attempts': 3,
+                u'notes': u'',
+                u'passive_checks_enabled': True,
+                u'retry_interval': 1
+            }
+        })
 
         # Get host data to confirm update
         response = session.get('http://127.0.0.1:5000/host', auth=self.auth,
@@ -979,8 +1377,25 @@ class TestModuleWs(AlignakTest):
         response = session.patch('http://127.0.0.1:8888/host', json=data, headers=headers)
         self.assertEqual(response.status_code, 200)
         result = response.json()
-        self.assertEqual(result, {u'_status': u'OK', u'_result': [u"test_host_0 is alive :)",
-                                                                  u"Host 'test_host_0' updated."]})
+        self.assertEqual(result, {
+            u'_status': u'OK',
+            u'_result': [u"test_host_0 is alive :)", u"Host 'test_host_0' updated."],
+            u'_feedback': {
+                u'_overall_state_id': 3,
+                u'active_checks_enabled': False,
+                u'alias': u'up_0',
+                u'check_freshness': False,
+                u'check_interval': 1,
+                u'freshness_state': u'x',
+                u'freshness_threshold': -1,
+                u'location': {u'coordinates': [46.60611, 1.87528],
+                              u'type': u'Point'},
+                u'max_check_attempts': 3,
+                u'notes': u'',
+                u'passive_checks_enabled': True,
+                u'retry_interval': 1
+            }
+        })
 
         # Get host data to confirm update
         response = session.get('http://127.0.0.1:5000/host', auth=self.auth,
@@ -1024,6 +1439,7 @@ class TestModuleWs(AlignakTest):
         self.assertEqual(result, {
             u'_status': u'ERR',
             u'_result': [u'test_host_0 is alive :)', u"Host 'test_host_0' unchanged."],
+            u'_feedback': {u'services': {}},
             u'_issues': [u"Requested service 'test_host_0/test_service' does not exist"]
         })
         # ----------
@@ -1050,12 +1466,41 @@ class TestModuleWs(AlignakTest):
         response = session.patch('http://127.0.0.1:8888/host', json=data, headers=headers)
         self.assertEqual(response.status_code, 200)
         result = response.json()
-        print(result)
         self.assertEqual(result, {
             u'_status': u'OK',
             u'_result': [u'test_host_0 is alive :)',
                          u"Service 'test_host_0/test_ok_0' updated",
-                         u"Host 'test_host_0' unchanged."]
+                         u"Host 'test_host_0' unchanged."],
+            u'_feedback': {
+                u'_overall_state_id': 3,
+                u'active_checks_enabled': False,
+                u'alias': u'up_0',
+                u'check_freshness': False,
+                u'check_interval': 1,
+                u'freshness_state': u'x',
+                u'freshness_threshold': -1,
+                u'location': {u'coordinates': [46.60611, 1.87528],
+                              u'type': u'Point'},
+                u'max_check_attempts': 3,
+                u'notes': u'',
+                u'passive_checks_enabled': True,
+                u'retry_interval': 1,
+                u'services': {
+                    u'test_ok_0': {
+                        u'_overall_state_id': 3,
+                        u'active_checks_enabled': True,
+                        u'alias': u'',
+                        u'check_freshness': False,
+                        u'check_interval': 1,
+                        u'freshness_state': u'x',
+                        u'freshness_threshold': -1,
+                        u'max_check_attempts': 2,
+                        u'notes': u'just a notes string',
+                        u'passive_checks_enabled': True,
+                        u'retry_interval': 1
+                    },
+                }
+            }
         })
 
         # Get host data to confirm update
@@ -1175,7 +1620,25 @@ class TestModuleWs(AlignakTest):
         response = session.patch('http://127.0.0.1:8888/host', json=data, headers=headers)
         self.assertEqual(response.status_code, 200)
         result = response.json()
-        self.assertEqual(result, {u'_status': u'OK', u'_result': [u'test_host_0 is alive :)']})
+        self.assertEqual(result, {
+            u'_status': u'OK',
+            u'_result': [u'test_host_0 is alive :)'],
+            u'_feedback': {
+                u'_overall_state_id': 3,
+                u'active_checks_enabled': True,
+                u'alias': u'up_0',
+                u'check_freshness': False,
+                u'check_interval': 1,
+                u'freshness_state': u'x',
+                u'freshness_threshold': -1,
+                u'location': {u'coordinates': [46.60611, 1.87528],
+                              u'type': u'Point'},
+                u'max_check_attempts': 3,
+                u'notes': u'',
+                u'passive_checks_enabled': True,
+                u'retry_interval': 1
+            }
+        })
 
         # ----------
         # Host does not exist
@@ -1189,9 +1652,11 @@ class TestModuleWs(AlignakTest):
         response = session.patch('http://127.0.0.1:8888/host', json=data, headers=headers)
         self.assertEqual(response.status_code, 200)
         result = response.json()
-        self.assertEqual(result, {u'_status': u'ERR',
-                                  u'_result': [u'unknown_host is alive :)'],
-                                  u'_issues': [u"Requested host 'unknown_host' does not exist"]})
+        self.assertEqual(result, {
+            u'_status': u'ERR',
+            u'_result': [u'unknown_host is alive :)'],
+            u'_feedback': {},
+            u'_issues': [u"Requested host 'unknown_host' does not exist"]})
 
         # ----------
         # Enable all checks
@@ -1205,10 +1670,25 @@ class TestModuleWs(AlignakTest):
         response = session.patch('http://127.0.0.1:8888/host', json=data, headers=headers)
         self.assertEqual(response.status_code, 200)
         result = response.json()
-        self.assertEqual(result, {u'_status': u'OK', u'_result': [
-            u'test_host_0 is alive :)',
-            u"Host 'test_host_0' unchanged."
-        ]})
+        self.assertEqual(result, {
+            u'_status': u'OK',
+            u'_result': [u'test_host_0 is alive :)', u"Host 'test_host_0' unchanged."],
+            u'_feedback': {
+                u'_overall_state_id': 3,
+                u'active_checks_enabled': True,
+                u'alias': u'up_0',
+                u'check_freshness': False,
+                u'check_interval': 1,
+                u'freshness_state': u'x',
+                u'freshness_threshold': -1,
+                u'location': {u'coordinates': [46.60611, 1.87528],
+                              u'type': u'Point'},
+                u'max_check_attempts': 3,
+                u'notes': u'',
+                u'passive_checks_enabled': True,
+                u'retry_interval': 1
+            }
+        })
 
         # Get host data to confirm update
         response = session.get('http://127.0.0.1:5000/host', auth=self.auth,
@@ -1231,10 +1711,25 @@ class TestModuleWs(AlignakTest):
         response = session.patch('http://127.0.0.1:8888/host', json=data, headers=headers)
         self.assertEqual(response.status_code, 200)
         result = response.json()
-        self.assertEqual(result, {u'_status': u'OK', u'_result': [
-            u'test_host_0 is alive :)',
-            u"Host 'test_host_0' unchanged."
-        ]})
+        self.assertEqual(result, {
+            u'_status': u'OK',
+            u'_result': [u'test_host_0 is alive :)', u"Host 'test_host_0' unchanged."],
+            u'_feedback': {
+                u'_overall_state_id': 3,
+                u'active_checks_enabled': True,
+                u'alias': u'up_0',
+                u'check_freshness': False,
+                u'check_interval': 1,
+                u'freshness_state': u'x',
+                u'freshness_threshold': -1,
+                u'location': {u'coordinates': [46.60611, 1.87528],
+                              u'type': u'Point'},
+                u'max_check_attempts': 3,
+                u'notes': u'',
+                u'passive_checks_enabled': True,
+                u'retry_interval': 1
+            }
+        })
 
         # Get host data to confirm update
         response = session.get('http://127.0.0.1:5000/host', auth=self.auth,
@@ -1257,14 +1752,32 @@ class TestModuleWs(AlignakTest):
         response = session.patch('http://127.0.0.1:8888/host', json=data, headers=headers)
         self.assertEqual(response.status_code, 200)
         result = response.json()
-        self.assertEqual(result, {u'_status': u'OK', u'_result': [
-            u'test_host_0 is alive :)',
-            u'Host test_host_0 active checks will be disabled.',
-            u'Sent external command: DISABLE_HOST_CHECK;test_host_0.',
-            u'Host test_host_0 passive checks will be disabled.',
-            u'Sent external command: DISABLE_PASSIVE_HOST_CHECKS;test_host_0.',
-            u"Host 'test_host_0' updated."
-        ]})
+        self.assertEqual(result, {
+            u'_status': u'OK',
+            u'_result': [
+                u'test_host_0 is alive :)',
+                u'Host test_host_0 active checks will be disabled.',
+                u'Sent external command: DISABLE_HOST_CHECK;test_host_0.',
+                u'Host test_host_0 passive checks will be disabled.',
+                u'Sent external command: DISABLE_PASSIVE_HOST_CHECKS;test_host_0.',
+                u"Host 'test_host_0' updated."
+            ],
+            u'_feedback': {
+                u'_overall_state_id': 3,
+                u'active_checks_enabled': False,
+                u'alias': u'up_0',
+                u'check_freshness': False,
+                u'check_interval': 1,
+                u'freshness_state': u'x',
+                u'freshness_threshold': -1,
+                u'location': {u'coordinates': [46.60611, 1.87528],
+                              u'type': u'Point'},
+                u'max_check_attempts': 3,
+                u'notes': u'',
+                u'passive_checks_enabled': False,
+                u'retry_interval': 1
+            }
+        })
 
         # Get host data to confirm update
         response = session.get('http://127.0.0.1:5000/host', auth=self.auth,
@@ -1287,12 +1800,30 @@ class TestModuleWs(AlignakTest):
         response = session.patch('http://127.0.0.1:8888/host', json=data, headers=headers)
         self.assertEqual(response.status_code, 200)
         result = response.json()
-        self.assertEqual(result, {u'_status': u'OK', u'_result': [
-            u'test_host_0 is alive :)',
-            u'Host test_host_0 active checks will be enabled.',
-            u'Sent external command: ENABLE_HOST_CHECK;test_host_0.',
-            u"Host 'test_host_0' updated."
-        ]})
+        self.assertEqual(result, {
+            u'_status': u'OK',
+            u'_result': [
+                u'test_host_0 is alive :)',
+                u'Host test_host_0 active checks will be enabled.',
+                u'Sent external command: ENABLE_HOST_CHECK;test_host_0.',
+                u"Host 'test_host_0' updated."
+            ],
+            u'_feedback': {
+                u'_overall_state_id': 3,
+                u'active_checks_enabled': True,
+                u'alias': u'up_0',
+                u'check_freshness': False,
+                u'check_interval': 1,
+                u'freshness_state': u'x',
+                u'freshness_threshold': -1,
+                u'location': {u'coordinates': [46.60611, 1.87528],
+                              u'type': u'Point'},
+                u'max_check_attempts': 3,
+                u'notes': u'',
+                u'passive_checks_enabled': False,
+                u'retry_interval': 1
+            }
+        })
 
         # Get host data to confirm update
         response = session.get('http://127.0.0.1:5000/host', auth=self.auth,
@@ -1315,14 +1846,32 @@ class TestModuleWs(AlignakTest):
         response = session.patch('http://127.0.0.1:8888/host', json=data, headers=headers)
         self.assertEqual(response.status_code, 200)
         result = response.json()
-        self.assertEqual(result, {u'_status': u'OK', u'_result': [
-            u'test_host_0 is alive :)',
-            u'Host test_host_0 active checks will be disabled.',
-            u'Sent external command: DISABLE_HOST_CHECK;test_host_0.',
-            u'Host test_host_0 passive checks will be enabled.',
-            u'Sent external command: ENABLE_PASSIVE_HOST_CHECKS;test_host_0.',
-            u"Host 'test_host_0' updated."
-        ]})
+        self.assertEqual(result, {
+            u'_status': u'OK',
+            u'_result': [
+                u'test_host_0 is alive :)',
+                u'Host test_host_0 active checks will be disabled.',
+                u'Sent external command: DISABLE_HOST_CHECK;test_host_0.',
+                u'Host test_host_0 passive checks will be enabled.',
+                u'Sent external command: ENABLE_PASSIVE_HOST_CHECKS;test_host_0.',
+                u"Host 'test_host_0' updated."
+            ],
+            u'_feedback': {
+                u'_overall_state_id': 3,
+                u'active_checks_enabled': False,
+                u'alias': u'up_0',
+                u'check_freshness': False,
+                u'check_interval': 1,
+                u'freshness_state': u'x',
+                u'freshness_threshold': -1,
+                u'location': {u'coordinates': [46.60611, 1.87528],
+                              u'type': u'Point'},
+                u'max_check_attempts': 3,
+                u'notes': u'',
+                u'passive_checks_enabled': True,
+                u'retry_interval': 1
+            }
+        })
 
         # Get host data to confirm update
         response = session.get('http://127.0.0.1:5000/host', auth=self.auth,
@@ -1366,6 +1915,7 @@ class TestModuleWs(AlignakTest):
             u'_status': u'ERR',
             u'_result': [u'test_host_0 is alive :)',
                          u"Host 'test_host_0' unchanged."],
+            u'_feedback': {u'services': {}},
             u'_issues': [u"Requested service 'test_host_0/test_service' does not exist",
                          u"Requested service 'test_host_0/test_service3' does not exist",
                          u"Requested service 'test_host_0/test_service2' does not exist"]
@@ -1416,7 +1966,64 @@ class TestModuleWs(AlignakTest):
                 u'Sent external command: DISABLE_PASSIVE_SVC_CHECKS;test_host_0;test_ok_1.',
                 u"Service 'test_host_0/test_ok_1' updated",
                 u"Host 'test_host_0' unchanged."
-            ]
+            ],
+            u'_feedback': {
+                u'_overall_state_id': 3,
+                u'active_checks_enabled': False,
+                u'alias': u'up_0',
+                u'check_freshness': False,
+                u'check_interval': 1,
+                u'freshness_state': u'x',
+                u'freshness_threshold': -1,
+                u'location': {u'coordinates': [46.60611, 1.87528],
+                              u'type': u'Point'},
+                u'max_check_attempts': 3,
+                u'notes': u'',
+                u'passive_checks_enabled': True,
+                u'retry_interval': 1,
+                u'services': {
+                    u'test_service': {
+                        u'_overall_state_id': 3,
+                        u'active_checks_enabled': True,
+                        u'alias': u'',
+                        u'check_freshness': False,
+                        u'check_interval': 1,
+                        u'freshness_state': u'x',
+                        u'freshness_threshold': -1,
+                        u'max_check_attempts': 2,
+                        u'notes': u'just a notes string',
+                        u'passive_checks_enabled': True,
+                        u'retry_interval': 1
+                    },
+                    u'test_service2': {
+                        u'_overall_state_id': 3,
+                        u'active_checks_enabled': False,
+                        u'alias': u'',
+                        u'check_freshness': False,
+                        u'check_interval': 1,
+                        u'freshness_state': u'x',
+                        u'freshness_threshold': -1,
+                        u'max_check_attempts': 2,
+                        u'notes': u'just a notes string',
+                        u'passive_checks_enabled': False,
+                        u'retry_interval': 1
+                    },
+                    u'test_service3': {
+                        u'_overall_state_id': 3,
+                        u'active_checks_enabled': True,
+                        u'alias': u'',
+                        u'check_freshness': False,
+                        u'check_interval': 1,
+                        u'freshness_state': u'x',
+                        u'freshness_threshold': -1,
+                        u'max_check_attempts': 2,
+                        u'notes': u'just a notes string',
+                        u'passive_checks_enabled': False,
+                        u'retry_interval': 1
+                    }
+                }
+
+            }
         })
 
         # Get host data to confirm update

--- a/test/test_module_host_creation.py
+++ b/test/test_module_host_creation.py
@@ -213,6 +213,21 @@ class TestModuleWs(AlignakTest):
                 u'new_host_0 is alive :)',
                 u"Requested host 'new_host_0' does not exist.",
                 u"Requested host 'new_host_0' created."],
+            u'_feedback': {
+                u'_overall_state_id': 3,
+                u'active_checks_enabled': True,
+                u'alias': u'',
+                u'check_freshness': False,
+                u'check_interval': 5,
+                u'freshness_state': u'x',
+                u'freshness_threshold': 0,
+                u'location': {u'coordinates': [46.3613628, 6.5394704],
+                              u'type': u'Point'},
+                u'max_check_attempts': 1,
+                u'notes': u'',
+                u'passive_checks_enabled': True,
+                u'retry_interval': 0
+            }
         })
         # Host created with default check_command and in default user realm
 
@@ -235,7 +250,25 @@ class TestModuleWs(AlignakTest):
         response = session.patch('http://127.0.0.1:8888/host', json=data, headers=headers)
         self.assertEqual(response.status_code, 200)
         result = response.json()
-        self.assertEqual(result, {u'_status': u'OK', u'_result': [u'new_host_0 is alive :)']})
+        self.assertEqual(result, {
+            u'_status': u'OK',
+            u'_result': [u'new_host_0 is alive :)'],
+            u'_feedback': {
+                u'_overall_state_id': 3,
+                u'active_checks_enabled': True,
+                u'alias': u'',
+                u'check_freshness': False,
+                u'check_interval': 5,
+                u'freshness_state': u'x',
+                u'freshness_threshold': 0,
+                u'location': {u'coordinates': [46.3613628, 6.5394704],
+                              u'type': u'Point'},
+                u'max_check_attempts': 1,
+                u'notes': u'',
+                u'passive_checks_enabled': True,
+                u'retry_interval': 0
+            }
+        })
         # The host already exists, returns an host alive ;)
 
         # Request to create an host - unknown provided data
@@ -258,6 +291,21 @@ class TestModuleWs(AlignakTest):
                 u"Requested host 'new_host_1' does not exist.",
                 u"Requested host 'new_host_1' created."
             ],
+            u'_feedback': {
+                u'_overall_state_id': 3,
+                u'active_checks_enabled': True,
+                u'alias': u'',
+                u'check_freshness': False,
+                u'check_interval': 5,
+                u'freshness_state': u'x',
+                u'freshness_threshold': 0,
+                u'location': {u'coordinates': [46.3613628, 6.5394704],
+                              u'type': u'Point'},
+                u'max_check_attempts': 1,
+                u'notes': u'',
+                u'passive_checks_enabled': True,
+                u'retry_interval': 0
+            }
         })
         # Host created, even if check_command does not exist, it uses the default check_command!
 
@@ -281,6 +329,21 @@ class TestModuleWs(AlignakTest):
                 u"Requested host 'new_host_2' does not exist.",
                 u"Requested host 'new_host_2' created."
             ],
+            u'_feedback': {
+                u'_overall_state_id': 3,
+                u'active_checks_enabled': True,
+                u'alias': u'',
+                u'check_freshness': False,
+                u'check_interval': 5,
+                u'freshness_state': u'x',
+                u'freshness_threshold': 0,
+                u'location': {u'coordinates': [46.3613628, 6.5394704],
+                              u'type': u'Point'},
+                u'max_check_attempts': 1,
+                u'notes': u'',
+                u'passive_checks_enabled': True,
+                u'retry_interval': 0
+            }
         })
         # No errors!
 
@@ -321,6 +384,21 @@ class TestModuleWs(AlignakTest):
                 u"PROCESS_HOST_CHECK_RESULT;new_host_3;0;Output...|'counter'=1\nLong output...",
                 u"Host 'new_host_3' unchanged."
             ],
+            u'_feedback': {
+                u'_overall_state_id': 3,
+                u'active_checks_enabled': True,
+                u'alias': u'',
+                u'check_freshness': False,
+                u'check_interval': 1,
+                u'freshness_state': u'x',
+                u'freshness_threshold': 0,
+                u'location': {u'coordinates': [46.60611, 1.87528],
+                              u'type': u'Point'},
+                u'max_check_attempts': 3,
+                u'notes': u'',
+                u'passive_checks_enabled': True,
+                u'retry_interval': 1
+            }
         })
         # No errors!
 
@@ -437,6 +515,21 @@ class TestModuleWs(AlignakTest):
                 u"Requested host 'new_host_for_services_0' does not exist.",
                 u"Requested host 'new_host_for_services_0' created."
             ],
+            u'_feedback': {
+                u'_overall_state_id': 3,
+                u'active_checks_enabled': True,
+                u'alias': u'',
+                u'check_freshness': False,
+                u'check_interval': 5,
+                u'freshness_state': u'x',
+                u'freshness_threshold': 0,
+                u'location': {u'coordinates': [46.3613628, 6.5394704],
+                              u'type': u'Point'},
+                u'max_check_attempts': 1,
+                u'notes': u'',
+                u'passive_checks_enabled': True,
+                u'retry_interval': 0
+            }
         })
         # No errors!
 
@@ -479,6 +572,33 @@ class TestModuleWs(AlignakTest):
                 u"Service 'new_host_for_services_0/test_ok_0' updated",
                 u"Host 'new_host_for_services_0' unchanged."
             ],
+            u'_feedback': {
+                u'_overall_state_id': 3,
+                u'active_checks_enabled': True,
+                u'alias': u'',
+                u'check_freshness': False,
+                u'check_interval': 5,
+                u'freshness_state': u'x',
+                u'freshness_threshold': 0,
+                u'location': {u'coordinates': [46.3613628, 6.5394704],
+                              u'type': u'Point'},
+                u'max_check_attempts': 1,
+                u'notes': u'',
+                u'passive_checks_enabled': True,
+                u'retry_interval': 0,
+                u'services': {u'new_service': {u'_overall_state_id': 3,
+                                               u'active_checks_enabled': True,
+                                               u'alias': u'',
+                                               u'check_freshness': False,
+                                               u'check_interval': 5,
+                                               u'freshness_state': u'o',
+                                               u'freshness_threshold': 0,
+                                               u'max_check_attempts': 1,
+                                               u'notes': u'',
+                                               u'passive_checks_enabled': True,
+                                               u'retry_interval': 0}
+                              }
+            }
         })
         # No errors!
 
@@ -542,6 +662,33 @@ class TestModuleWs(AlignakTest):
                 u"Service 'new_host_for_services_0/test_ok_1' updated",
                 u"Host 'new_host_for_services_0' unchanged."
             ],
+            u'_feedback': {
+                u'_overall_state_id': 3,
+                u'active_checks_enabled': True,
+                u'alias': u'',
+                u'check_freshness': False,
+                u'check_interval': 5,
+                u'freshness_state': u'x',
+                u'freshness_threshold': 0,
+                u'location': {u'coordinates': [46.3613628, 6.5394704],
+                              u'type': u'Point'},
+                u'max_check_attempts': 1,
+                u'notes': u'',
+                u'passive_checks_enabled': True,
+                u'retry_interval': 0,
+                u'services': {u'new_service': {u'_overall_state_id': 3,
+                                               u'active_checks_enabled': True,
+                                               u'alias': u'',
+                                               u'check_freshness': False,
+                                               u'check_interval': 1,
+                                               u'freshness_state': u'o',
+                                               u'freshness_threshold': 0,
+                                               u'max_check_attempts': 2,
+                                               u'notes': u'',
+                                               u'passive_checks_enabled': True,
+                                               u'retry_interval': 1}
+                              }
+            }
         })
         # No errors!
 

--- a/test/test_module_host_creation.py
+++ b/test/test_module_host_creation.py
@@ -623,7 +623,7 @@ class TestModuleWs(AlignakTest):
         }
         self.assertEqual(expected, service['customs'])
 
-        # Create a new host with a template and Update host livestate (heartbeat / host is alive): livestate
+        # Create a new service with a template and update service livestate and data
         data = {
             "name": "new_host_for_services_0",
             "services": {
@@ -692,7 +692,7 @@ class TestModuleWs(AlignakTest):
         })
         # No errors!
 
-        # Get new host to confirm creation
+        # Get new service to confirm creation
         response = session.get('http://127.0.0.1:5000/host', auth=self.auth,
                                 params={'where': json.dumps({'name': 'new_host_for_services_0'})})
         resp = response.json()


### PR DESCRIPTION
When using the `host` endpoint, the client will get some feedback from Alignak. Some variables will be returned to the client to reflect the real host/service status and configuration