### PR TITLE
Fix bug with default_realm

### DIFF
--- a/alignak_module_ws/ws.py
+++ b/alignak_module_ws/ws.py
@@ -1082,14 +1082,11 @@ class AlignakWebServices(BaseModule):
         :return: None
         """
         self.token = None
-        
         if not password:
             # We consider that we received a backend token as login. The WS user is logged-in...
             self.token = username
-            return self.token
-        
-        self.default_realm = None
-        
+            return self.token     
+        self.default_realm = None   
         try:
             if self.backend.login(username, password):
                 self.token = self.backend.token

--- a/alignak_module_ws/ws.py
+++ b/alignak_module_ws/ws.py
@@ -1085,8 +1085,8 @@ class AlignakWebServices(BaseModule):
         if not password:
             # We consider that we received a backend token as login. The WS user is logged-in...
             self.token = username
-            return self.token     
-        self.default_realm = None   
+            return self.token
+        self.default_realm = None
         try:
             if self.backend.login(username, password):
                 self.token = self.backend.token

--- a/alignak_module_ws/ws.py
+++ b/alignak_module_ws/ws.py
@@ -1082,13 +1082,14 @@ class AlignakWebServices(BaseModule):
         :return: None
         """
         self.token = None
-        self.default_realm = None
-
+        
         if not password:
             # We consider that we received a backend token as login. The WS user is logged-in...
             self.token = username
             return self.token
-
+        
+        self.default_realm = None
+        
         try:
             if self.backend.login(username, password):
                 self.token = self.backend.token


### PR DESCRIPTION
IF you put the default_realm = none BEFORE The check for token it gets set to None and never gets reset since that only happens on login with username/password.