### PR TITLE
Update the Alignak backend check results with events in the past

### DIFF
--- a/alignak_module_ws/etc/arbiter/modules/mod-ws.cfg
+++ b/alignak_module_ws/etc/arbiter/modules/mod-ws.cfg
@@ -59,6 +59,14 @@ define module {
 
 
     # ---------------
+    # Set timestamp for the external commands
+    #set_timestamp             1
+    # Give feedback when updating the livestate
+    # Return some information about the host/service updated
+    #give_feedback             1
+    # ---------------
+
+    # ---------------
     # Interface configuration
     # ---------------
     # Interface the modules listens to

--- a/alignak_module_ws/ws.py
+++ b/alignak_module_ws/ws.py
@@ -102,6 +102,10 @@ class AlignakWebServices(BaseModule):
         self.set_timestamp = getattr(mod_conf, 'set_timestamp', '1') == '1'
         logger.info("Alignak external commands, set timestamp: %s", self.set_timestamp)
 
+        # Give some feedback when updating the livestate
+        self.give_feedback = getattr(mod_conf, 'give_feedback', '1') == '1'
+        logger.info("Alignak update livestate, set give_feedback: %s", self.give_feedback)
+
         # Alignak Backend part
         # ---
         self.backend_available = False
@@ -673,7 +677,7 @@ class AlignakWebServices(BaseModule):
                         ws_result['_issues'].append("Host state must be UP, DOWN or UNREACHABLE"
                                                     ", and not '%s'." % (state))
                     else:
-                        ws_result['_result'].append(self.buildHostLivestate(host_name,
+                        ws_result['_result'].append(self.buildHostLivestate(host,
                                                                             livestate))
 
         # Update host services
@@ -701,21 +705,24 @@ class AlignakWebServices(BaseModule):
                 ws_result['_status'] = 'ERR'
                 return ws_result
 
-            host = self.backend.get('/'.join(['host', host['_id']]))
-            ws_result['_feedback'].update({
-                'alias': host['alias'],
-                'notes': host['notes'],
-                'location': host['location'],
-                'active_checks_enabled': host['active_checks_enabled'],
-                'max_check_attempts': host['max_check_attempts'],
-                'check_interval': host['check_interval'],
-                'retry_interval': host['retry_interval'],
-                'passive_checks_enabled': host['passive_checks_enabled'],
-                'check_freshness': host['check_freshness'],
-                'freshness_state': host['freshness_state'],
-                'freshness_threshold': host['freshness_threshold'],
-                '_overall_state_id': host['_overall_state_id']
-            })
+            if self.give_feedback:
+                host = self.backend.get('/'.join(['host', host['_id']]))
+                ws_result['_feedback'].update({
+                    'alias': host['alias'],
+                    'notes': host['notes'],
+                    'location': host['location'],
+                    'active_checks_enabled': host['active_checks_enabled'],
+                    'max_check_attempts': host['max_check_attempts'],
+                    'check_interval': host['check_interval'],
+                    'retry_interval': host['retry_interval'],
+                    'passive_checks_enabled': host['passive_checks_enabled'],
+                    'check_freshness': host['check_freshness'],
+                    'freshness_state': host['freshness_state'],
+                    'freshness_threshold': host['freshness_threshold'],
+                    '_overall_state_id': host['_overall_state_id']
+                })
+            else:
+                ws_result.pop('_feedback')
 
             ws_result.pop('_issues')
             return ws_result
@@ -728,21 +735,24 @@ class AlignakWebServices(BaseModule):
                 ws_result['_status'] = 'ERR'
                 return ws_result
 
-            host = self.backend.get('/'.join(['host', host['_id']]))
-            ws_result['_feedback'].update({
-                'alias': host['alias'],
-                'notes': host['notes'],
-                'location': host['location'],
-                'active_checks_enabled': host['active_checks_enabled'],
-                'max_check_attempts': host['max_check_attempts'],
-                'check_interval': host['check_interval'],
-                'retry_interval': host['retry_interval'],
-                'passive_checks_enabled': host['passive_checks_enabled'],
-                'check_freshness': host['check_freshness'],
-                'freshness_state': host['freshness_state'],
-                'freshness_threshold': host['freshness_threshold'],
-                '_overall_state_id': host['_overall_state_id']
-            })
+            if self.give_feedback:
+                host = self.backend.get('/'.join(['host', host['_id']]))
+                ws_result['_feedback'].update({
+                    'alias': host['alias'],
+                    'notes': host['notes'],
+                    'location': host['location'],
+                    'active_checks_enabled': host['active_checks_enabled'],
+                    'max_check_attempts': host['max_check_attempts'],
+                    'check_interval': host['check_interval'],
+                    'retry_interval': host['retry_interval'],
+                    'passive_checks_enabled': host['passive_checks_enabled'],
+                    'check_freshness': host['check_freshness'],
+                    'freshness_state': host['freshness_state'],
+                    'freshness_threshold': host['freshness_threshold'],
+                    '_overall_state_id': host['_overall_state_id']
+                })
+            else:
+                ws_result.pop('_feedback')
 
             ws_result.pop('_issues')
             return ws_result
@@ -766,21 +776,24 @@ class AlignakWebServices(BaseModule):
                 logger.warning("Host patch, got a problem: %s", result)
                 return ('ERR', patch_result['_issues'])
 
-            host = self.backend.get('/'.join(['host', host['_id']]))
-            ws_result['_feedback'].update({
-                'alias': host['alias'],
-                'notes': host['notes'],
-                'location': host['location'],
-                'active_checks_enabled': host['active_checks_enabled'],
-                'max_check_attempts': host['max_check_attempts'],
-                'check_interval': host['check_interval'],
-                'retry_interval': host['retry_interval'],
-                'passive_checks_enabled': host['passive_checks_enabled'],
-                'check_freshness': host['check_freshness'],
-                'freshness_state': host['freshness_state'],
-                'freshness_threshold': host['freshness_threshold'],
-                '_overall_state_id': host['_overall_state_id']
-            })
+            if self.give_feedback:
+                host = self.backend.get('/'.join(['host', host['_id']]))
+                ws_result['_feedback'].update({
+                    'alias': host['alias'],
+                    'notes': host['notes'],
+                    'location': host['location'],
+                    'active_checks_enabled': host['active_checks_enabled'],
+                    'max_check_attempts': host['max_check_attempts'],
+                    'check_interval': host['check_interval'],
+                    'retry_interval': host['retry_interval'],
+                    'passive_checks_enabled': host['passive_checks_enabled'],
+                    'check_freshness': host['check_freshness'],
+                    'freshness_state': host['freshness_state'],
+                    'freshness_threshold': host['freshness_threshold'],
+                    '_overall_state_id': host['_overall_state_id']
+                })
+            else:
+                ws_result.pop('_feedback')
         except BackendException as exp:  # pragma: no cover, should not happen
             logger.warning("Alignak backend is currently not available.")
             logger.warning("Exception: %s", exp)
@@ -958,58 +971,59 @@ class AlignakWebServices(BaseModule):
                                                     "CRITICAL, UNKNOWN or UNREACHABLE, and not %s."
                                                     % (service_name, state))
                     else:
-                        ws_result['_result'].append(self.buildServiceLivestate(host['name'],
-                                                                               service_name,
+                        ws_result['_result'].append(self.buildServiceLivestate(host, service,
                                                                                livestate))
 
         # If no update requested
         if update is None:
-            # Simple host alive without any required update
+            # Simple service alive without any required update
             if ws_result['_issues']:
                 ws_result['_status'] = 'ERR'
                 return ws_result
 
-            service = self.backend.get('/'.join(['service', service['_id']]))
-            ws_result['_feedback'] = {
-                'alias': service['alias'],
-                'notes': service['notes'],
-                'active_checks_enabled': service['active_checks_enabled'],
-                'max_check_attempts': service['max_check_attempts'],
-                'check_interval': service['check_interval'],
-                'retry_interval': service['retry_interval'],
-                'passive_checks_enabled': service['passive_checks_enabled'],
-                'check_freshness': service['check_freshness'],
-                'freshness_state': service['freshness_state'],
-                'freshness_threshold': service['freshness_threshold'],
-                '_overall_state_id': service['_overall_state_id']
-            }
+            if self.give_feedback:
+                service = self.backend.get('/'.join(['service', service['_id']]))
+                ws_result['_feedback'] = {
+                    'alias': service['alias'],
+                    'notes': service['notes'],
+                    'active_checks_enabled': service['active_checks_enabled'],
+                    'max_check_attempts': service['max_check_attempts'],
+                    'check_interval': service['check_interval'],
+                    'retry_interval': service['retry_interval'],
+                    'passive_checks_enabled': service['passive_checks_enabled'],
+                    'check_freshness': service['check_freshness'],
+                    'freshness_state': service['freshness_state'],
+                    'freshness_threshold': service['freshness_threshold'],
+                    '_overall_state_id': service['_overall_state_id']
+                }
 
             ws_result.pop('_issues')
             return ws_result
 
         # If no update needed
         if not update:
-            # Simple host alive with updates required but no update needed
+            # Simple service alive with updates required but no update needed
             ws_result['_result'].append("Service '%s/%s' unchanged."
                                         % (host['name'], service_name))
             if ws_result['_issues']:
                 ws_result['_status'] = 'ERR'
                 return ws_result
 
-            service = self.backend.get('/'.join(['service', service['_id']]))
-            ws_result['_feedback'] = {
-                'alias': service['alias'],
-                'notes': service['notes'],
-                'active_checks_enabled': service['active_checks_enabled'],
-                'max_check_attempts': service['max_check_attempts'],
-                'check_interval': service['check_interval'],
-                'retry_interval': service['retry_interval'],
-                'passive_checks_enabled': service['passive_checks_enabled'],
-                'check_freshness': service['check_freshness'],
-                'freshness_state': service['freshness_state'],
-                'freshness_threshold': service['freshness_threshold'],
-                '_overall_state_id': service['_overall_state_id']
-            }
+            if self.give_feedback:
+                service = self.backend.get('/'.join(['service', service['_id']]))
+                ws_result['_feedback'] = {
+                    'alias': service['alias'],
+                    'notes': service['notes'],
+                    'active_checks_enabled': service['active_checks_enabled'],
+                    'max_check_attempts': service['max_check_attempts'],
+                    'check_interval': service['check_interval'],
+                    'retry_interval': service['retry_interval'],
+                    'passive_checks_enabled': service['passive_checks_enabled'],
+                    'check_freshness': service['check_freshness'],
+                    'freshness_state': service['freshness_state'],
+                    'freshness_threshold': service['freshness_threshold'],
+                    '_overall_state_id': service['_overall_state_id']
+                }
 
             ws_result.pop('_issues')
             return ws_result
@@ -1031,20 +1045,21 @@ class AlignakWebServices(BaseModule):
                 logger.warning("Service patch, got a problem: %s", result)
                 return ('ERR', patch_result['_issues'])
 
-            service = self.backend.get('/'.join(['service', service['_id']]))
-            ws_result['_feedback'] = {
-                'alias': service['alias'],
-                'notes': service['notes'],
-                'active_checks_enabled': service['active_checks_enabled'],
-                'max_check_attempts': service['max_check_attempts'],
-                'check_interval': service['check_interval'],
-                'retry_interval': service['retry_interval'],
-                'passive_checks_enabled': service['passive_checks_enabled'],
-                'check_freshness': service['check_freshness'],
-                'freshness_state': service['freshness_state'],
-                'freshness_threshold': service['freshness_threshold'],
-                '_overall_state_id': service['_overall_state_id']
-            }
+            if self.give_feedback:
+                service = self.backend.get('/'.join(['service', service['_id']]))
+                ws_result['_feedback'] = {
+                    'alias': service['alias'],
+                    'notes': service['notes'],
+                    'active_checks_enabled': service['active_checks_enabled'],
+                    'max_check_attempts': service['max_check_attempts'],
+                    'check_interval': service['check_interval'],
+                    'retry_interval': service['retry_interval'],
+                    'passive_checks_enabled': service['passive_checks_enabled'],
+                    'check_freshness': service['check_freshness'],
+                    'freshness_state': service['freshness_state'],
+                    'freshness_threshold': service['freshness_threshold'],
+                    '_overall_state_id': service['_overall_state_id']
+                }
 
         except BackendException as exp:  # pragma: no cover, should not happen
             logger.warning("Alignak backend is currently not available.")
@@ -1128,12 +1143,14 @@ class AlignakWebServices(BaseModule):
         result.pop('_issues')
         return result
 
-    def buildHostLivestate(self, host_name, livestate):
+    def buildHostLivestate(self, host, livestate):
         """Build and notify the external command for an host livestate
 
         PROCESS_HOST_CHECK_RESULT;<host_name>;<status_code>;<plugin_output>
 
-        :param host_name: host name
+        Create and post a logcheckresult to the backend if the timestamp is in the past
+
+        :param host: host from the Alignak backend
         :param livestate: livestate dictionary
         :return: command line
         """
@@ -1160,7 +1177,7 @@ class AlignakWebServices(BaseModule):
         elif perf_data:
             parameters = '%s|%s' % (parameters, perf_data)
 
-        command_line = 'PROCESS_HOST_CHECK_RESULT;%s;%s' % (host_name, parameters)
+        command_line = 'PROCESS_HOST_CHECK_RESULT;%s;%s' % (host['name'], parameters)
         if timestamp is not None:
             command_line = '[%d] %s' % (timestamp, command_line)
         elif self.set_timestamp:
@@ -1170,15 +1187,66 @@ class AlignakWebServices(BaseModule):
         logger.debug("Sending command: %s", command_line)
         self.to_q.put(ExternalCommand(command_line))
 
+        # -------------------------------------------
+        # Add a check result for an host if we got a timestamp in the past
+        # A passive check with a timestamp older than the host last check data will not be
+        # managed by Alignak but we may track this event in the backend logcheckresult
+        if timestamp and (not host['ls_last_check'] or timestamp < host['ls_last_check']):
+            logger.info("Recording a check result from the past...")
+            # Assume data are in the host livestate
+            data = {
+                "last_check": timestamp,
+                "host": host['_id'],
+                "service": None,
+                'acknowledged': host['ls_acknowledged'],
+                'acknowledgement_type': host['ls_acknowledgement_type'],
+                'downtimed': host['ls_downtimed'],
+                'state_id': state_to_id[state],
+                'state': state,
+                'state_type': host['ls_state_type'],
+                'last_state': host['ls_last_state'],
+                'last_state_type': host['ls_last_state_type'],
+                'latency': 0,
+                'execution_time': 0,
+                'output': output,
+                'long_output': long_output,
+                'perf_data': perf_data,
+                "_realm": host['_realm']
+            }
+            result = self.backend.get('/logcheckresult',
+                                      {'max_results': 1,
+                                       'where': json.dumps({'host_name': host['name'],
+                                                            'last_check': {"$lte": timestamp}})})
+            logger.debug("Get logcheckresult, got: %s", result)
+            if result['_items']:
+                lcr = result['_items'][0]
+                logger.info("Updating data from an existing logcheckresult: %s", lcr)
+                # Assume some data are in the most recent check result
+                data.update({
+                    'acknowledged': lcr['acknowledged'],
+                    'acknowledgement_type': lcr['acknowledgement_type'],
+                    'downtimed': lcr['downtimed'],
+                    'state_type': lcr['state_type'],
+                    'last_state': lcr['last_state'],
+                    'last_state_type': lcr['last_state_type'],
+                    'state_changed': lcr['state_changed']
+                })
+
+            result = self.backend.post('/logcheckresult', data)
+            if result['_status'] != 'OK':
+                logger.warning("Post logcheckresult, error: %s", result)
+
         return command_line
 
-    def buildServiceLivestate(self, host_name, service_name, livestate):
+    def buildServiceLivestate(self, host, service, livestate):
         """Build and notify the external command for a service livestate
 
         PROCESS_SERVICE_CHECK_RESULT;<host_name>;<service_description>;<return_code>;<plugin_output>
 
-        :param host_name: host name
-        :param service_name: service description
+        Create and post a logcheckresult to the backend if the timestamp is in the past
+
+        :param host: host from the Alignak backend
+        :param service: service from the Alignak backend
         :param livestate: livestate dictionary
         :return: command line
         """
@@ -1208,7 +1276,7 @@ class AlignakWebServices(BaseModule):
             parameters = '%s|%s' % (parameters, perf_data)
 
         command_line = 'PROCESS_SERVICE_CHECK_RESULT;%s;%s;%s' % \
-                       (host_name, service_name, parameters)
+                       (host['name'], service['name'], parameters)
         if timestamp is not None:
             command_line = '[%d] %s' % (timestamp, command_line)
         elif self.set_timestamp:
@@ -1217,6 +1285,56 @@ class AlignakWebServices(BaseModule):
         # Add a command to get managed
         logger.debug("Sending command: %s", command_line)
         self.to_q.put(ExternalCommand(command_line))
+
+        # -------------------------------------------
+        # Add a check result for a service if we got a timestamp in the past
+        # A passive check with a timestamp older than the service last check data will not be
+        # managed by Alignak but we may track this event in the backend logcheckresult
+        if timestamp and (not service['ls_last_check'] or timestamp < service['ls_last_check']):
+            logger.info("Recording a check result from the past...")
+            # Assume data are in the host livestate
+            data = {
+                "last_check": timestamp,
+                "host": host['_id'],
+                "service": service['_id'],
+                'acknowledged': service['ls_acknowledged'],
+                'acknowledgement_type': service['ls_acknowledgement_type'],
+                'downtimed': service['ls_downtimed'],
+                'state_id': state_to_id[state],
+                'state': state,
+                'state_type': service['ls_state_type'],
+                'last_state': service['ls_last_state'],
+                'last_state_type': service['ls_last_state_type'],
+                'latency': 0,
+                'execution_time': 0,
+                'output': output,
+                'long_output': long_output,
+                'perf_data': perf_data,
+                "_realm": service['_realm']
+            }
+            result = self.backend.get('/logcheckresult',
+                                      {'max_results': 1,
+                                       'where': json.dumps({'host_name': host['name'],
+                                                            'service_name': service['name'],
+                                                            'last_check': {"$lte": timestamp}})})
+            logger.debug("Get logcheckresult, got: %s", result)
+            if result['_items']:
+                lcr = result['_items'][0]
+                logger.info("Updating data from an existing logcheckresult: %s", lcr)
+                # Assume some data are in the most recent check result
+                data.update({
+                    'acknowledged': lcr['acknowledged'],
+                    'acknowledgement_type': lcr['acknowledgement_type'],
+                    'downtimed': lcr['downtimed'],
+                    'state_type': lcr['state_type'],
+                    'last_state': lcr['last_state'],
+                    'last_state_type': lcr['last_state_type'],
+                    'state_changed': lcr['state_changed']
+                })
+
+            result = self.backend.post('/logcheckresult', data)
+            if result['_status'] != 'OK':
+                logger.warning("Post logcheckresult, error: %s", result)
 
         return command_line
 

--- a/docs/source/04_services/05-host-report.rst
+++ b/docs/source/04_services/05-host-report.rst
@@ -146,6 +146,7 @@ The livestate data for an host or service may contain:
 - `perf_data`: the host/service check performance data
 - `timestamp`: timestamp for the host/service check
 
+**Note** that the `livestate` for the host or for any service may be an array if more than one result is to be reported to the Web Service.
 
 Host custom variables
 ~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/04_services/05-host-report.rst
+++ b/docs/source/04_services/05-host-report.rst
@@ -155,10 +155,10 @@ To create/update host custom variables, PATCH on the `host` endpoint providing t
     $ curl -X PATCH -H "Content-Type: application/json" -d '{
         "name": "test_host",
         "variables": {
-            'test1': 'string',
-            'test2': 12,
-            'test3': 15055.0,
-            'test4': "new!"
+            "test1": "string",
+            "test2": 12,
+            "test3": 15055.0,
+            "test4": "new!"
         }
     }' "http://demo.alignak.net:8888/host"
 

--- a/test/host-simulator.json
+++ b/test/host-simulator.json
@@ -2,8 +2,69 @@
    "hosts": [
       {
          "name": "win-passive-[%02d-0-9]",
+         "active_checks_enabled": false,
+         "passive_checks_enabled": true,
+         "_sub_realm": false,
 
          "services": {
+            "fake_service": {
+               "name": "fake",
+               "active_checks_enabled": false,
+               "passive_checks_enabled": true,
+                "livestate": {
+                    "state": "OK",
+                    "output": "WS output - I am ok!"
+                }
+            },
+            "test_service": {
+               "name": "nsca_uptime",
+               "active_checks_enabled": false,
+               "passive_checks_enabled": true
+            },
+            "test_service2": {
+               "name": "nsca_cpu",
+               "active_checks_enabled": false,
+               "passive_checks_enabled": true
+            },
+            "test_service3": {
+               "name": "nsca_memory",
+               "active_checks_enabled": false,
+               "passive_checks_enabled": true
+            },
+            "test_service4": {
+               "name": "nsca_disk",
+               "active_checks_enabled": false,
+               "passive_checks_enabled": true
+            }
+         }
+      },
+      {
+         "name": "win-passive-bis-[%02d-0-9]",
+         "active_checks_enabled": false,
+         "passive_checks_enabled": true,
+         "_sub_realm": false,
+
+         "services": {
+            "test_service": {
+               "name": "nsca_uptime",
+               "active_checks_enabled": false,
+               "passive_checks_enabled": true
+            },
+            "test_service2": {
+               "name": "nsca_cpu",
+               "active_checks_enabled": false,
+               "passive_checks_enabled": true
+            },
+            "test_service3": {
+               "name": "nsca_memory",
+               "active_checks_enabled": false,
+               "passive_checks_enabled": true
+            },
+            "test_service4": {
+               "name": "nsca_disk",
+               "active_checks_enabled": false,
+               "passive_checks_enabled": true
+            }
              "test_service": {
                  "name": "nsca_uptime"
              },

--- a/test/host-simulator.py
+++ b/test/host-simulator.py
@@ -409,7 +409,7 @@ class HostSimulator(object):
                                         perfdatas.append("'disk_%s_percent_used'=%.2f%%"
                                                          % (disk, getattr(disk_usage, key)))
                                     else:
-                                        perfdatas.append("'disk_%s_%s'=%db"
+                                        perfdatas.append("'disk_%s_%s'=%dB"
                                                          % (disk, key, getattr(disk_usage, key)))
 
 
@@ -430,7 +430,7 @@ class HostSimulator(object):
                                     perfdatas.append("'mem_percent_used_%s'=%.2f%%"
                                                      % (key, getattr(virtual_memory, key)))
                                 else:
-                                    perfdatas.append("'mem_%s'=%db"
+                                    perfdatas.append("'mem_%s'=%dB"
                                                      % (key, getattr(virtual_memory, key)))
 
                             swap_memory = psutil.swap_memory()
@@ -440,7 +440,7 @@ class HostSimulator(object):
                                     perfdatas.append("'swap_used_%s'=%.2f%%"
                                                      % (key, getattr(swap_memory, key)))
                                 else:
-                                    perfdatas.append("'swap_%s'=%db"
+                                    perfdatas.append("'swap_%s'=%dB"
                                                      % (key, getattr(swap_memory, key)))
 
                             service["livestate"] = {

--- a/test/test_module.py
+++ b/test/test_module.py
@@ -360,19 +360,21 @@ class TestModuleWs(AlignakTest):
         self.assert_log_match(
             re.escape("Alignak external commands, set timestamp: True"), 3)
         self.assert_log_match(
+            re.escape("Alignak update livestate, set give_feedback: True"), 4)
+        self.assert_log_match(
             re.escape("Alignak Backend is not configured. "
-                      "Some module features will not be available."), 4)
+                      "Some module features will not be available."), 5)
         self.assert_log_match(
-            re.escape("Alignak Arbiter configuration: 127.0.0.1:7770"), 5)
+            re.escape("Alignak Arbiter configuration: 127.0.0.1:7770"), 6)
         self.assert_log_match(
-            re.escape("Alignak Arbiter polling period: 5"), 6)
+            re.escape("Alignak Arbiter polling period: 5"), 7)
         self.assert_log_match(
-            re.escape("Alignak daemons get status period: 10"), 7)
+            re.escape("Alignak daemons get status period: 10"), 8)
         self.assert_log_match(
             re.escape("SSL is not enabled, this is not recommended. "
-                      "You should consider enabling SSL!"), 8)
+                      "You should consider enabling SSL!"), 9)
         self.assert_log_match(
-            re.escape("configuration, listening on: http://0.0.0.0:8888"), 9)
+            re.escape("configuration, listening on: http://0.0.0.0:8888"), 10)
 
     def test_module_start_parameters(self):
         """
@@ -417,22 +419,24 @@ class TestModuleWs(AlignakTest):
         self.assert_log_match(
             re.escape("Alignak external commands, set timestamp: False"), 3)
         self.assert_log_match(
+            re.escape("Alignak update livestate, set give_feedback: True"), 4)
+        self.assert_log_match(
             re.escape("Alignak Backend is not configured. "
-                      "Some module features will not be available."), 4)
+                      "Some module features will not be available."), 5)
         self.assert_log_match(
-            re.escape("Alignak Arbiter configuration: my_host:80"), 5)
+            re.escape("Alignak Arbiter configuration: my_host:80"), 6)
         self.assert_log_match(
-            re.escape("Alignak Arbiter polling period: 5"), 6)
+            re.escape("Alignak Arbiter polling period: 5"), 7)
         self.assert_log_match(
-            re.escape("Alignak daemons get status period: 10"), 7)
+            re.escape("Alignak daemons get status period: 10"), 8)
         self.assert_log_match(
             re.escape("The CA certificate /usr/local/etc/alignak/certs/ca.pem is missing "
-                      "(ca_cert). Please fix it in your configuration"), 8)
+                      "(ca_cert). Please fix it in your configuration"), 9)
         self.assert_log_match(
             re.escape("SSL is not enabled, this is not recommended. "
-                      "You should consider enabling SSL!"), 9)
+                      "You should consider enabling SSL!"), 10)
         self.assert_log_match(
-            re.escape("configuration, listening on: http://me:8080"), 10)
+            re.escape("configuration, listening on: http://me:8080"), 11)
 
     def test_module_zzz_basic_ws(self):
         """Test the module basic API - authorization enabled

--- a/test/test_module_host.py
+++ b/test/test_module_host.py
@@ -1797,7 +1797,7 @@ class TestModuleWs(AlignakTest):
         self.assertEqual(result, {
             u'_status': u'OK',
             u'_result': [u"test_host_0 is alive :)",
-                         u"Host 'test_host_0' updated."],
+                         u"Host 'test_host_0' unchanged."],
             u'_feedback': {
                 u'_overall_state_id': 3,
                 u'active_checks_enabled': False,
@@ -1980,6 +1980,78 @@ class TestModuleWs(AlignakTest):
         # ----------
 
         # ----------
+        # New host variables as an array
+        headers = {'Content-Type': 'application/json'}
+        data = {
+            "name": "test_host_0",
+            "variables": {
+                'test1': 'string modified',
+                'test2': 12,
+                'test3': 15055.0,
+                'my_array': [
+                    {
+                        "id": "identifier", "name": "my name", "other": 1
+                    },
+                    {
+                        "id": "identifier", "name": "my name", "other": 1
+                    }
+                ],
+                'packages': [
+                    {
+                        "id": "identifier", "name": "Package 1", "other": 1
+                    },
+                    {
+                        "id": "identifier", "name": "Package 2", "other": 1
+                    }
+                ]
+            },
+        }
+        self.assertEqual(my_module.received_commands, 0)
+        response = session.patch('http://127.0.0.1:8888/host', json=data, headers=headers)
+        self.assertEqual(response.status_code, 200)
+        result = response.json()
+        self.assertEqual(result, {
+            u'_status': u'OK',
+            u'_result': [u'test_host_0 is alive :)', u"Host 'test_host_0' updated."],
+            u'_feedback': {
+                u'_overall_state_id': 3,
+                u'active_checks_enabled': False,
+                u'alias': u'up_0',
+                u'check_freshness': False,
+                u'check_interval': 1,
+                u'freshness_state': u'x',
+                u'freshness_threshold': -1,
+                u'location': {u'coordinates': [48.858293, 2.294601],
+                              u'type': u'Point'},
+                u'max_check_attempts': 3,
+                u'notes': u'',
+                u'passive_checks_enabled': True,
+                u'retry_interval': 1
+            }
+        })
+
+        # Get host data to confirm update
+        response = session.get('http://127.0.0.1:5000/host', auth=self.auth,
+                                params={'where': json.dumps({'name': 'test_host_0'})})
+        resp = response.json()
+        test_host_0 = resp['_items'][0]
+        expected = {
+            u'_DISPLAY_NAME': u'test_host_0', u'_TEMPLATE': u'generic',
+            u'_OSLICENSE': u'gpl', u'_OSTYPE': u'gnulinux',
+            u'_TEST3': 15055.0, u'_TEST2': 12, u'_TEST1': u'string modified', u'_TEST4': u'new!',
+            u'_MY_ARRAY': [
+                {u'id': u'identifier', u'name': u'my name', u'other': 1},
+                {u'id': u'identifier', u'name': u'my name', u'other': 1}
+            ],
+            u'_PACKAGES': [
+                {u'id': u'identifier', u'name': u'Package 1', u'other': 1},
+                {u'id': u'identifier', u'name': u'Package 2', u'other': 1}
+            ],
+        }
+        self.assertEqual(expected, test_host_0['customs'])
+        # ----------
+
+        # ----------
         # Create host service variables - unknown service
         headers = {'Content-Type': 'application/json'}
         data = {
@@ -2085,6 +2157,14 @@ class TestModuleWs(AlignakTest):
             u'_ICON_IMAGE_ALT': u'icon alt string',
             u'_OSLICENSE': u'gpl', u'_OSTYPE': u'gnulinux',
             u'_CUSTNAME': u'custvalue',
+            u'_MY_ARRAY': [
+                {u'id': u'identifier', u'name': u'my name', u'other': 1},
+                {u'id': u'identifier', u'name': u'my name', u'other': 1}
+            ],
+            u'_PACKAGES': [
+                {u'id': u'identifier', u'name': u'Package 1', u'other': 1},
+                {u'id': u'identifier', u'name': u'Package 2', u'other': 1}
+            ],
             u'_TEST3': 5.0, u'_TEST2': 1, u'_TEST1': u'string',
             u'_TEST4': u'new!',
             u'_TEST5': u'service specific'
@@ -2703,3 +2783,231 @@ class TestModuleWs(AlignakTest):
         self.assertEqual(result['_result'], 'Logged out')
 
         self.modulemanager.stop_all()
+
+    def test_module_zzz_host_no_feedback(self):
+        """Test the module /host API * create/update custom variables * no feedback in the response
+        :return:
+        """
+        self.print_header()
+        # Obliged to call to get a self.logger...
+        self.setup_with_file('cfg/cfg_default.cfg')
+        self.assertTrue(self.conf_is_correct)
+
+        # Create an Alignak module
+        mod = Module({
+            'module_alias': 'web-services',
+            'module_types': 'web-services',
+            'python_name': 'alignak_module_ws',
+            # Alignak backend
+            'alignak_backend': 'http://127.0.0.1:5000',
+            'username': 'admin',
+            'password': 'admin',
+            # Do not set a timestamp in the built external commands
+            'set_timestamp': '0',
+            # Do not give feedback data
+            'give_feedback': '0',
+            # Set Arbiter address as empty to not poll the Arbiter else the test will fail!
+            'alignak_host': '',
+            'alignak_port': 7770,
+        })
+
+        # Create the modules manager for a daemon type
+        self.modulemanager = ModulesManager('receiver', None)
+
+        # Load an initialize the modules:
+        #  - load python module
+        #  - get module properties and instances
+        self.modulemanager.load_and_init([mod])
+
+        my_module = self.modulemanager.instances[0]
+
+        # Clear logs
+        self.clear_logs()
+
+        # Start external modules
+        self.modulemanager.start_external_instances()
+
+        # Starting external module logs
+        self.assert_log_match("Trying to initialize module: web-services", 0)
+        self.assert_log_match("Starting external module web-services", 1)
+        self.assert_log_match("Starting external process for module web-services", 2)
+        self.assert_log_match("web-services is now started", 3)
+
+        # Check alive
+        self.assertIsNotNone(my_module.process)
+        self.assertTrue(my_module.process.is_alive())
+
+        time.sleep(1)
+
+        # Get host data to confirm backend update
+        # ---
+        response = requests.get('http://127.0.0.1:5000/host', auth=self.auth,
+                                params={'where': json.dumps({'name': 'test_host_0'})})
+        resp = response.json()
+        test_host_0 = resp['_items'][0]
+        # ---
+
+        # Do not allow GET request on /host - not authorized
+        response = requests.get('http://127.0.0.1:8888/host')
+        self.assertEqual(response.status_code, 401)
+
+        session = requests.Session()
+
+        # Login with username/password (real backend login)
+        headers = {'Content-Type': 'application/json'}
+        params = {'username': 'admin', 'password': 'admin'}
+        response = session.post('http://127.0.0.1:8888/login', json=params, headers=headers)
+        assert response.status_code == 200
+        resp = response.json()
+
+        # You must have parameters when POSTing on /host
+        headers = {'Content-Type': 'application/json'}
+        data = {}
+        response = session.patch('http://127.0.0.1:8888/host', json=data, headers=headers)
+        self.assertEqual(response.status_code, 200)
+        result = response.json()
+        self.assertEqual(result['_status'], 'ERR')
+        self.assertEqual(result['_error'], 'You must send parameters on this endpoint.')
+
+        # Update host variables - empty variables
+        headers = {'Content-Type': 'application/json'}
+        data = {
+            "name": "test_host_0",
+            "variables": "",
+        }
+        self.assertEqual(my_module.received_commands, 0)
+        response = session.patch('http://127.0.0.1:8888/host', json=data, headers=headers)
+        self.assertEqual(response.status_code, 200)
+        result = response.json()
+        self.assertEqual(result, {
+            u'_status': u'OK',
+            u'_result': [u'test_host_0 is alive :)']
+        })
+
+        # Get host data to confirm update
+        response = session.get('http://127.0.0.1:5000/host', auth=self.auth,
+                                params={'where': json.dumps({'name': 'test_host_0'})})
+        resp = response.json()
+        test_host_0 = resp['_items'][0]
+        expected = {
+            u'_DISPLAY_NAME': u'test_host_0', u'_TEMPLATE': u'generic',
+            u'_OSLICENSE': u'gpl', u'_OSTYPE': u'gnulinux'
+        }
+        self.assertEqual(expected, test_host_0['customs'])
+
+        # ----------
+        # Host does not exist
+        headers = {'Content-Type': 'application/json'}
+        data = {
+            "name": "unknown_host",
+            "variables": {
+                'test1': 'string',
+                'test2': 1,
+                'test3': 5.0
+            },
+        }
+        self.assertEqual(my_module.received_commands, 0)
+        response = session.patch('http://127.0.0.1:8888/host', json=data, headers=headers)
+        self.assertEqual(response.status_code, 200)
+        result = response.json()
+        self.assertEqual(result, {u'_status': u'ERR',
+                                  u'_result': [u'unknown_host is alive :)'],
+                                  u'_feedback': {},
+                                  u'_issues': [u"Requested host 'unknown_host' does not exist"]})
+
+
+        # ----------
+        # Create host variables
+        headers = {'Content-Type': 'application/json'}
+        data = {
+            "name": "test_host_0",
+            "variables": {
+                'test1': 'string',
+                'test2': 1,
+                'test3': 5.0
+            },
+        }
+        self.assertEqual(my_module.received_commands, 0)
+        response = session.patch('http://127.0.0.1:8888/host', json=data, headers=headers)
+        self.assertEqual(response.status_code, 200)
+        result = response.json()
+        self.assertEqual(result, {
+            u'_status': u'OK',
+            u'_result': [u"test_host_0 is alive :)",
+                         u"Host 'test_host_0' updated."]
+        })
+
+        # Get host data to confirm update
+        response = session.get('http://127.0.0.1:5000/host', auth=self.auth,
+                                params={'where': json.dumps({'name': 'test_host_0'})})
+        resp = response.json()
+        test_host_0 = resp['_items'][0]
+        expected = {
+            u'_DISPLAY_NAME': u'test_host_0', u'_TEMPLATE': u'generic',
+            u'_OSLICENSE': u'gpl', u'_OSTYPE': u'gnulinux',
+            u'_TEST3': 5.0, u'_TEST2': 1, u'_TEST1': u'string'
+        }
+        self.assertEqual(expected, test_host_0['customs'])
+
+        # ----------
+        # Create host service variables
+        headers = {'Content-Type': 'application/json'}
+        data = {
+            "name": "test_host_0",
+
+            "services": {
+                "test_ok_0": {
+                    "name": "test_ok_0",
+                    "variables": {
+                        'test1': 'string',
+                        'test2': 1,
+                        'test3': 5.0,
+                        'test5': 'service specific'
+                    },
+                },
+            }
+        }
+        self.assertEqual(my_module.received_commands, 0)
+        response = session.patch('http://127.0.0.1:8888/host', json=data, headers=headers)
+        self.assertEqual(response.status_code, 200)
+        result = response.json()
+        self.assertEqual(result, {
+            u'_status': u'OK',
+            u'_result': [u'test_host_0 is alive :)',
+                         u"Service 'test_host_0/test_ok_0' updated",
+                         u"Host 'test_host_0' unchanged."]
+        })
+
+        # Get host data to confirm update
+        response = session.get('http://127.0.0.1:5000/host', auth=self.auth,
+                                params={'where': json.dumps({'name': 'test_host_0'})})
+        resp = response.json()
+        host = resp['_items'][0]
+        # Get services data to confirm update
+        response = requests.get('http://127.0.0.1:5000/service', auth=self.auth,
+                                params={'where': json.dumps({'host': host['_id'],
+                                                             'name': 'test_ok_0'})})
+        resp = response.json()
+        service = resp['_items'][0]
+        # The service still had a variable _CUSTNAME and it inherits from the host variables
+        expected = {
+            u'_DISPLAY_NAME': u'test_host_0', u'_TEMPLATE': u'generic',
+            u'_ICON_IMAGE': u'../../docs/images/tip.gif?host=$HOSTNAME$&srv=$SERVICEDESC$',
+            u'_ICON_IMAGE_ALT': u'icon alt string',
+            u'_OSLICENSE': u'gpl', u'_OSTYPE': u'gnulinux',
+            u'_CUSTNAME': u'custvalue',
+            u'_TEST3': 5.0, u'_TEST2': 1, u'_TEST1': u'string',
+            u'_TEST5': u'service specific'
+        }
+        self.assertEqual(expected, service['customs'])
+        # ----------
+
+        # Logout
+        response = session.get('http://127.0.0.1:8888/logout')
+        self.assertEqual(response.status_code, 200)
+        result = response.json()
+        self.assertEqual(result['_status'], 'OK')
+        self.assertEqual(result['_result'], 'Logged out')
+
+        self.modulemanager.stop_all()
+

--- a/test/test_module_host.py
+++ b/test/test_module_host.py
@@ -601,7 +601,7 @@ class TestModuleWs(AlignakTest):
         self.modulemanager.stop_all()
 
     def test_module_simulate_host(self):
-        """Simulate an hos on the /host API
+        """Simulate an host on the /host API
         :return:
         """
         self.print_header()
@@ -723,6 +723,146 @@ class TestModuleWs(AlignakTest):
                 u"PROCESS_SERVICE_CHECK_RESULT;test_host_0;test_ok_2;2;Output...|'counter'=1\nLong output...",
                 u"Service 'test_host_0/test_ok_2' unchanged.",
                 u"PROCESS_SERVICE_CHECK_RESULT;test_host_0;test_ok_1;1;Output...|'counter'=1\nLong output...",
+                u"Service 'test_host_0/test_ok_1' unchanged.",
+                u"Host 'test_host_0' unchanged."
+            ],
+            u'_feedback': {
+                u'_overall_state_id': 3,
+                u'active_checks_enabled': True,
+                u'alias': u'up_0',
+                u'check_freshness': False,
+                u'check_interval': 1,
+                u'freshness_state': u'x',
+                u'freshness_threshold': -1,
+                u'location': {u'coordinates': [48.858293, 2.294601],
+                              u'type': u'Point'},
+                u'max_check_attempts': 3,
+                u'notes': u'',
+                u'passive_checks_enabled': True,
+                u'retry_interval': 1,
+                u'services': {
+                    u'test_service': {
+                        u'_overall_state_id': 3,
+                        u'active_checks_enabled': False,
+                        u'alias': u'test_ok_0',
+                        u'check_freshness': False,
+                        u'check_interval': 1,
+                        u'freshness_state': u'x',
+                        u'freshness_threshold': -1,
+                        u'max_check_attempts': 2,
+                        u'notes': u'just a notes string',
+                        u'passive_checks_enabled': False,
+                        u'retry_interval': 1
+                    },
+                    u'test_service2': {
+                        u'_overall_state_id': 3,
+                        u'active_checks_enabled': True,
+                        u'alias': u'test_ok_1',
+                        u'check_freshness': False,
+                        u'check_interval': 1,
+                        u'freshness_state': u'x',
+                        u'freshness_threshold': -1,
+                        u'max_check_attempts': 2,
+                        u'notes': u'just a notes string',
+                        u'passive_checks_enabled': True,
+                        u'retry_interval': 1
+                    },
+                    u'test_service3': {
+                        u'_overall_state_id': 3,
+                        u'active_checks_enabled': False,
+                        u'alias': u'test_ok_2',
+                        u'check_freshness': False,
+                        u'check_interval': 1,
+                        u'freshness_state': u'x',
+                        u'freshness_threshold': -1,
+                        u'max_check_attempts': 2,
+                        u'notes': u'just a notes string',
+                        u'passive_checks_enabled': True,
+                        u'retry_interval': 1
+                    }
+                }
+            }
+        })
+
+        # Update host services livestate - several checks in the livestate
+        headers = {'Content-Type': 'application/json'}
+        data = {
+            "name": host_name,
+            "livestate": [
+                {
+                    "timestamp": 123456789,
+                    "state": "up",
+                    "output": "Output...",
+                    "long_output": "Long output...",
+                    "perf_data": "'counter'=1"
+                },
+                {
+                    "timestamp": 123456789 + 3600,
+                    "state": "up",
+                    "output": "Output...",
+                    "long_output": "Long output...",
+                    "perf_data": "'counter'=1"
+                }
+            ],
+            "services": {
+                "test_service": {
+                    "name": "test_ok_0",
+                    # An array with one item
+                    "livestate": [
+                        {
+                            "timestamp": 123456789,
+                            "state": "ok",
+                            "output": "Output...",
+                            "long_output": "Long output...",
+                            "perf_data": "'counter'=1"
+                        }
+                    ]
+                },
+                "test_service2": {
+                    "name": "test_ok_1",
+                    # An array with one item
+                    "livestate": [
+                        {
+                            "timestamp": 123456789,
+                            "state": "warning",
+                            "output": "Output...",
+                            "long_output": "Long output...",
+                            "perf_data": "'counter'=1"
+                        },
+                        {
+                            "timestamp": 123456789 + 3600,
+                            "state": "ok",
+                            "output": "Output...",
+                            "long_output": "Long output...",
+                            "perf_data": "'counter'=2"
+                        }
+                    ]
+                },
+                "test_service3": {
+                    "name": "test_ok_2",
+                    "livestate": {
+                        "state": "critical",
+                        "output": "Output...",
+                        "long_output": "Long output...",
+                        "perf_data": "'counter'=1"
+                    }
+                },
+            },
+        }
+        response = session.patch('http://127.0.0.1:8888/host', json=data, headers=headers)
+        self.assertEqual(response.status_code, 200)
+        result = response.json()
+        self.assertEqual(result, {
+            u'_status': u'OK', u'_result': [
+                u'test_host_0 is alive :)',
+                u"[123456789] PROCESS_HOST_CHECK_RESULT;test_host_0;0;Output...|'counter'=1\nLong output...",
+                u"[123460389] PROCESS_HOST_CHECK_RESULT;test_host_0;0;Output...|'counter'=1\nLong output...",
+                u"[123456789] PROCESS_SERVICE_CHECK_RESULT;test_host_0;test_ok_0;0;Output...|'counter'=1\nLong output...",
+                u"Service 'test_host_0/test_ok_0' unchanged.",
+                u"PROCESS_SERVICE_CHECK_RESULT;test_host_0;test_ok_2;2;Output...|'counter'=1\nLong output...",
+                u"Service 'test_host_0/test_ok_2' unchanged.",
+                u"[123456789] PROCESS_SERVICE_CHECK_RESULT;test_host_0;test_ok_1;1;Output...|'counter'=1\nLong output...",
+                u"[123460389] PROCESS_SERVICE_CHECK_RESULT;test_host_0;test_ok_1;0;Output...|'counter'=2\nLong output...",
                 u"Service 'test_host_0/test_ok_1' unchanged.",
                 u"Host 'test_host_0' unchanged."
             ],

--- a/test/test_module_host_livestate.py
+++ b/test/test_module_host_livestate.py
@@ -1,0 +1,719 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2015-2016: Alignak team, see AUTHORS.txt file for contributors
+#
+# This file is part of Alignak.
+#
+# Alignak is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Alignak is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Alignak.  If not, see <http://www.gnu.org/licenses/>.
+#
+"""
+Test the module - host/service livestate
+"""
+
+import os
+import re
+import time
+import json
+
+import shlex
+import subprocess
+
+import logging
+
+import requests
+
+from alignak_test import AlignakTest, time_hacker
+from alignak.modulesmanager import ModulesManager
+from alignak.objects.module import Module
+from alignak.basemodule import BaseModule
+
+# Set environment variable to ask code Coverage collection
+os.environ['COVERAGE_PROCESS_START'] = '.coveragerc'
+
+import alignak_module_ws
+
+# # Activate debug logs for the alignak backend client library
+# logging.getLogger("alignak_backend_client.client").setLevel(logging.DEBUG)
+#
+# # Activate debug logs for the module
+# logging.getLogger("alignak.module.web-services").setLevel(logging.DEBUG)
+
+
+class TestModuleWs(AlignakTest):
+    """This class contains the tests for the module"""
+
+    @classmethod
+    def setUpClass(cls):
+
+        # Set test mode for alignak backend
+        os.environ['TEST_ALIGNAK_BACKEND'] = '1'
+        os.environ['ALIGNAK_BACKEND_MONGO_DBNAME'] = 'alignak-module-ws-backend-test'
+
+        # Delete used mongo DBs
+        print ("Deleting Alignak backend DB...")
+        exit_code = subprocess.call(
+            shlex.split(
+                'mongo %s --eval "db.dropDatabase()"' % os.environ['ALIGNAK_BACKEND_MONGO_DBNAME'])
+        )
+        assert exit_code == 0
+
+        fnull = open(os.devnull, 'w')
+        cls.p = subprocess.Popen(['uwsgi', '--plugin', 'python', '-w', 'alignakbackend:app',
+                                  '--socket', '0.0.0.0:5000',
+                                  '--protocol=http', '--enable-threads', '--pidfile',
+                                  '/tmp/uwsgi.pid'],
+                                 stdout=fnull, stderr=fnull)
+        time.sleep(3)
+
+        endpoint = 'http://127.0.0.1:5000'
+
+        test_dir = os.path.dirname(os.path.realpath(__file__))
+        print("Current test directory: %s" % test_dir)
+
+        print("Feeding Alignak backend...")
+        print('alignak-backend-import --delete %s/cfg/cfg_default.cfg' % test_dir)
+        exit_code = subprocess.call(
+            shlex.split('alignak-backend-import --delete %s/cfg/cfg_default.cfg' % test_dir),
+            stdout=fnull, stderr=fnull
+        )
+        assert exit_code == 0
+        print("Fed")
+
+        # Backend authentication
+        headers = {'Content-Type': 'application/json'}
+        params = {'username': 'admin', 'password': 'admin'}
+        # Get admin user token (force regenerate)
+        response = requests.post(endpoint + '/login', json=params, headers=headers)
+        resp = response.json()
+        cls.token = resp['token']
+        cls.auth = requests.auth.HTTPBasicAuth(cls.token, '')
+
+        # Get admin user
+        response = requests.get(endpoint + '/user', auth=cls.auth)
+        resp = response.json()
+        cls.user_admin = resp['_items'][0]
+
+        # Get realms
+        response = requests.get(endpoint + '/realm', auth=cls.auth)
+        resp = response.json()
+        cls.realmAll_id = resp['_items'][0]['_id']
+
+        # Add a user
+        data = {'name': 'test', 'password': 'test', 'back_role_super_admin': False,
+                'host_notification_period': cls.user_admin['host_notification_period'],
+                'service_notification_period': cls.user_admin['service_notification_period'],
+                '_realm': cls.realmAll_id}
+        response = requests.post(endpoint + '/user', json=data, headers=headers,
+                                 auth=cls.auth)
+        resp = response.json()
+        print("Created a new user: %s" % resp)
+
+        cls.modulemanager = None
+
+    @classmethod
+    def tearDownClass(cls):
+        if cls.modulemanager:
+            cls.modulemanager.stop_all()
+        cls.p.kill()
+
+    @classmethod
+    def tearDown(cls):
+        """Delete resources in backend
+
+        :return: None
+        """
+        for resource in ['logcheckresult']:
+            requests.delete('http://127.0.0.1:5000/' + resource, auth=cls.auth)
+
+    def test_module_zzz_host_livestate(self):
+        """Test the module /host API - host creation and livestate
+        :return:
+        """
+        self.print_header()
+        # Obliged to call to get a self.logger...
+        self.setup_with_file('cfg/cfg_default.cfg')
+        self.assertTrue(self.conf_is_correct)
+
+        # -----
+        # Provide parameters - logger configuration file (exists)
+        # -----
+        # Clear logs
+        self.clear_logs()
+
+        # Create an Alignak module
+        mod = Module({
+            'module_alias': 'web-services',
+            'module_types': 'web-services',
+            'python_name': 'alignak_module_ws',
+            # Alignak backend
+            'alignak_backend': 'http://127.0.0.1:5000',
+            'username': 'admin',
+            'password': 'admin',
+            # Do not set a timestamp in the built external commands
+            'set_timestamp': '0',
+            # Do not give feedback data
+            'give_feedback': '0',
+            # Set Arbiter address as empty to not poll the Arbiter else the test will fail!
+            'alignak_host': '',
+            'alignak_port': 7770,
+            # Allow host/service creation
+            'allow_host_creation': '1',
+            'allow_service_creation': '1'
+        })
+
+        # Create the modules manager for a daemon type
+        self.modulemanager = ModulesManager('receiver', None)
+
+        # Load an initialize the modules:
+        #  - load python module
+        #  - get module properties and instances
+        self.modulemanager.load_and_init([mod])
+
+        my_module = self.modulemanager.instances[0]
+
+        # Clear logs
+        self.clear_logs()
+
+        # Start external modules
+        self.modulemanager.start_external_instances()
+
+        # Starting external module logs
+        self.assert_log_match("Trying to initialize module: web-services", 0)
+        self.assert_log_match("Starting external module web-services", 1)
+        self.assert_log_match("Starting external process for module web-services", 2)
+        self.assert_log_match("web-services is now started", 3)
+
+        # Check alive
+        self.assertIsNotNone(my_module.process)
+        self.assertTrue(my_module.process.is_alive())
+
+        time.sleep(1)
+
+        # Alignak backend
+        # ---
+        self.endpoint = 'http://127.0.0.1:5000'
+        headers = {'Content-Type': 'application/json'}
+        params = {'username': 'admin', 'password': 'admin'}
+        # get token
+        response = requests.post(self.endpoint + '/login', json=params, headers=headers)
+        resp = response.json()
+        self.token = resp['token']
+        self.auth = requests.auth.HTTPBasicAuth(self.token, '')
+
+        # Do not allow GET request on /host - not authorized
+        response = requests.get('http://127.0.0.1:8888/host')
+        self.assertEqual(response.status_code, 401)
+
+        session = requests.Session()
+
+        # Login with username/password (real backend login)
+        headers = {'Content-Type': 'application/json'}
+        params = {'username': 'admin', 'password': 'admin'}
+        response = session.post('http://127.0.0.1:8888/login', json=params, headers=headers)
+        assert response.status_code == 200
+        resp = response.json()
+
+        # -----
+        # Create a new host with an host livestate (heartbeat / host is alive): livestate
+        data = {
+            "name": "new_host_0",
+            "livestate": {
+                # No timestamp in the livestate
+                "state": "UP",
+                "output": "Output...",
+                "long_output": "Long output...",
+                "perf_data": "'counter'=1",
+            }
+        }
+        self.assertEqual(my_module.received_commands, 0)
+        response = session.patch('http://127.0.0.1:8888/host', json=data, headers=headers)
+        self.assertEqual(response.status_code, 200)
+        result = response.json()
+        self.assertEqual(result, {
+            u'_status': u'OK',
+            u'_result': [
+                u'new_host_0 is alive :)',
+                u"Requested host 'new_host_0' does not exist.",
+                u"Requested host 'new_host_0' created.",
+                u"PROCESS_HOST_CHECK_RESULT;new_host_0;0;Output...|'counter'=1\nLong output...",
+                u"Host 'new_host_0' unchanged."
+            ]
+        })
+        # No errors!
+
+        # Get new host in the backend
+        response = requests.get(self.endpoint + '/host', auth=self.auth, params={'where': json.dumps({'name': 'new_host_0'})})
+        resp = response.json()
+        new_host_0 = resp['_items'][0]
+        self.assertEqual('new_host_0', new_host_0['name'])
+
+        # Get backend check results - no check result sent to the backend
+        response = requests.get(self.endpoint + '/logcheckresult', auth=self.auth)
+        resp = response.json()
+        rl = resp['_items']
+        self.assertEqual(len(rl), 0)
+
+
+        # -----
+        # Send an host livestate
+        data = {
+            "name": "new_host_0",
+            "livestate": {
+                # No timestamp in the livestate
+                "state": "UP",
+                "output": "Output...",
+                "long_output": "Long output...",
+                "perf_data": "'counter'=1",
+            }
+        }
+        self.assertEqual(my_module.received_commands, 0)
+        response = session.patch('http://127.0.0.1:8888/host', json=data, headers=headers)
+        self.assertEqual(response.status_code, 200)
+        result = response.json()
+        self.assertEqual(result, {
+            u'_status': u'OK',
+            u'_result': [
+                u'new_host_0 is alive :)',
+                u"PROCESS_HOST_CHECK_RESULT;new_host_0;0;Output...|'counter'=1\nLong output...",
+                u"Host 'new_host_0' unchanged."
+            ]
+        })
+        # No errors!
+
+        # Get backend check results - no check result sent to the backend
+        response = requests.get(self.endpoint + '/logcheckresult', auth=self.auth)
+        resp = response.json()
+        rl = resp['_items']
+        self.assertEqual(len(rl), 0)
+
+
+        # -----
+        # Send an host livestate with a timestamp in the past
+        now = int(time.time()) - 3600
+        data = {
+            "name": "new_host_0",
+            "livestate": {
+                # Timestamp in the past
+                "timestamp": now,
+                "state": "UP",
+                "output": "Output...",
+                "long_output": "Long output...",
+                "perf_data": "'counter'=1",
+            }
+        }
+        self.assertEqual(my_module.received_commands, 0)
+        response = session.patch('http://127.0.0.1:8888/host', json=data, headers=headers)
+        self.assertEqual(response.status_code, 200)
+        result = response.json()
+        self.assertEqual(result, {
+            u'_status': u'OK',
+            u'_result': [
+                u'new_host_0 is alive :)',
+                u"[%d] PROCESS_HOST_CHECK_RESULT;new_host_0;0;Output...|'counter'=1\nLong output..." % now,
+                u"Host 'new_host_0' unchanged."
+            ]
+        })
+        # No errors!
+
+        # Get backend check results - a check result was recorded in the backend
+        response = requests.get(self.endpoint + '/logcheckresult', auth=self.auth)
+        resp = response.json()
+        rl = resp['_items']
+        # A log check result was recorded...
+        self.assertEqual(len(rl), 1)
+        rl = resp['_items'][0]
+        print("LCR: %s" % rl)
+        # ...with the correct timestamp
+        self.assertEqual(rl['host_name'], "new_host_0")
+        self.assertEqual(rl['last_check'], now)
+
+        # -----
+        # Send an host livestate with a timestamp in the past but sooner than the former one
+        now = now + 1800
+        data = {
+            "name": "new_host_0",
+            "livestate": {
+                # Timestamp in the past
+                "timestamp": now,
+                "state": "UP",
+                "output": "Output...",
+                "long_output": "Long output...",
+                "perf_data": "'counter'=1",
+            }
+        }
+        self.assertEqual(my_module.received_commands, 0)
+        response = session.patch('http://127.0.0.1:8888/host', json=data, headers=headers)
+        self.assertEqual(response.status_code, 200)
+        result = response.json()
+        self.assertEqual(result, {
+            u'_status': u'OK',
+            u'_result': [
+                u'new_host_0 is alive :)',
+                u"[%d] PROCESS_HOST_CHECK_RESULT;new_host_0;0;Output...|'counter'=1\nLong output..." % now,
+                u"Host 'new_host_0' unchanged."
+            ]
+        })
+        # No errors!
+
+        # Get backend check results - one more check result was recorded in the backend
+        response = requests.get(self.endpoint + '/logcheckresult', auth=self.auth)
+        resp = response.json()
+        rl = resp['_items']
+        # A log check result was recorded...
+        self.assertEqual(len(rl), 2)
+        # Get the second LCR
+        rl = resp['_items'][1]
+        print("LCR: %s" % rl)
+        # ...with the correct timestamp
+        self.assertEqual(rl['host_name'], "new_host_0")
+        self.assertEqual(rl['last_check'], now)
+
+
+        # Logout
+        response = session.get('http://127.0.0.1:8888/logout')
+        self.assertEqual(response.status_code, 200)
+        result = response.json()
+        self.assertEqual(result['_status'], 'OK')
+        self.assertEqual(result['_result'], 'Logged out')
+
+        self.modulemanager.stop_all()
+
+    def test_module_zzz_service_livestate(self):
+        """Test the module /host API - service creation and livestate
+        :return:
+        """
+        self.print_header()
+        # Obliged to call to get a self.logger...
+        self.setup_with_file('cfg/cfg_default.cfg')
+        self.assertTrue(self.conf_is_correct)
+
+        # -----
+        # Provide parameters - logger configuration file (exists)
+        # -----
+        # Clear logs
+        self.clear_logs()
+
+        # Create an Alignak module
+        mod = Module({
+            'module_alias': 'web-services',
+            'module_types': 'web-services',
+            'python_name': 'alignak_module_ws',
+            # Alignak backend
+            'alignak_backend': 'http://127.0.0.1:5000',
+            'username': 'admin',
+            'password': 'admin',
+            # Do not set a timestamp in the built external commands
+            'set_timestamp': '0',
+            # Do not give feedback data
+            'give_feedback': '0',
+            # Set Arbiter address as empty to not poll the Arbiter else the test will fail!
+            'alignak_host': '',
+            'alignak_port': 7770,
+            # Allow host/service creation
+            'allow_host_creation': '1',
+            'allow_service_creation': '1'
+        })
+
+        # Create the modules manager for a daemon type
+        self.modulemanager = ModulesManager('receiver', None)
+
+        # Load an initialize the modules:
+        #  - load python module
+        #  - get module properties and instances
+        self.modulemanager.load_and_init([mod])
+
+        my_module = self.modulemanager.instances[0]
+
+        # Clear logs
+        self.clear_logs()
+
+        # Start external modules
+        self.modulemanager.start_external_instances()
+
+        # Starting external module logs
+        self.assert_log_match("Trying to initialize module: web-services", 0)
+        self.assert_log_match("Starting external module web-services", 1)
+        self.assert_log_match("Starting external process for module web-services", 2)
+        self.assert_log_match("web-services is now started", 3)
+
+        # Check alive
+        self.assertIsNotNone(my_module.process)
+        self.assertTrue(my_module.process.is_alive())
+
+        time.sleep(1)
+
+        # Alignak backend
+        # ---
+        self.endpoint = 'http://127.0.0.1:5000'
+        headers = {'Content-Type': 'application/json'}
+        params = {'username': 'admin', 'password': 'admin'}
+        # get token
+        response = requests.post(self.endpoint + '/login', json=params, headers=headers)
+        resp = response.json()
+        self.token = resp['token']
+        self.auth = requests.auth.HTTPBasicAuth(self.token, '')
+
+        # Do not allow GET request on /host - not authorized
+        response = requests.get('http://127.0.0.1:8888/host')
+        self.assertEqual(response.status_code, 401)
+
+        session = requests.Session()
+
+        # Login with username/password (real backend login)
+        headers = {'Content-Type': 'application/json'}
+        params = {'username': 'admin', 'password': 'admin'}
+        response = session.post('http://127.0.0.1:8888/login', json=params, headers=headers)
+        assert response.status_code == 200
+        resp = response.json()
+
+        # Request to create an host - create a new host
+        headers = {'Content-Type': 'application/json'}
+        data = {
+            "name": "new_host_for_services_0",
+            "template": {
+                "_realm": 'All',
+                "check_command": "_internal_host_up"
+            }
+        }
+        self.assertEqual(my_module.received_commands, 0)
+        response = session.patch('http://127.0.0.1:8888/host', json=data, headers=headers)
+        self.assertEqual(response.status_code, 200)
+        result = response.json()
+        self.assertEqual(result, {
+            u'_status': u'OK',
+            u'_result': [
+                u'new_host_for_services_0 is alive :)',
+                u"Requested host 'new_host_for_services_0' does not exist.",
+                u"Requested host 'new_host_for_services_0' created."
+            ]
+        })
+        # No errors!
+
+        # Get new host in the backend
+        response = requests.get(self.endpoint + '/host', auth=self.auth, params={'where': json.dumps({'name': 'new_host_for_services_0'})})
+        resp = response.json()
+        new_host_for_services_0 = resp['_items'][0]
+        self.assertEqual('new_host_for_services_0', new_host_for_services_0['name'])
+
+        # Get backend check results - no check result sent to the backend
+        response = requests.get(self.endpoint + '/logcheckresult', auth=self.auth)
+        resp = response.json()
+        rl = resp['_items']
+        self.assertEqual(len(rl), 0)
+
+
+        # Request to create an host - create a new service without any template data
+        headers = {'Content-Type': 'application/json'}
+        data = {
+            "name": "new_host_for_services_0",
+            "services": {
+                "new_service": {
+                    "name": "test_empty_0",
+                    # "template": {
+                    #     "_realm": 'All',
+                    #     "check_command": "_echo"
+                    # },
+                    "livestate": {
+                        "state": "OK",
+                        "output": "Output...",
+                        "long_output": "Long output...",
+                        "perf_data": "'counter'=1",
+                    },
+                    "variables": {
+                        'test1': 'string',
+                        'test2': 1,
+                        'test3': 5.0
+                    },
+                }
+            }
+        }
+        self.assertEqual(my_module.received_commands, 0)
+        response = session.patch('http://127.0.0.1:8888/host', json=data, headers=headers)
+        self.assertEqual(response.status_code, 200)
+        result = response.json()
+        self.assertEqual(result, {
+            u'_status': u'OK',
+            u'_result': [
+                u'new_host_for_services_0 is alive :)',
+                u"Requested service 'new_host_for_services_0/test_empty_0' does not exist.",
+                u"Requested service 'new_host_for_services_0/test_empty_0' created.",
+                u"PROCESS_SERVICE_CHECK_RESULT;new_host_for_services_0;test_empty_0;0;Output...|'counter'=1\nLong output...",
+                u"Service 'new_host_for_services_0/test_empty_0' updated",
+                u"Host 'new_host_for_services_0' unchanged."
+            ]
+        })
+        # No errors!
+
+        # Get new host to confirm creation
+        response = requests.get(self.endpoint + '/host', auth=self.auth,
+                                params={'where': json.dumps({'name': 'new_host_for_services_0'})})
+        resp = response.json()
+        new_host_for_services_0 = resp['_items'][0]
+        self.assertEqual('new_host_for_services_0', new_host_for_services_0['name'])
+
+        # Get services data to confirm update
+        response = requests.get(self.endpoint + '/service', auth=self.auth,
+                                params={'where': json.dumps({'host': new_host_for_services_0['_id'],
+                                                             'name': 'test_empty_0'})})
+        resp = response.json()
+        service = resp['_items'][0]
+        expected = {
+            u'_TEST3': 5.0, u'_TEST2': 1, u'_TEST1': u'string'
+        }
+        self.assertEqual(expected, service['customs'])
+
+
+        # Send a service livestate, no timestamp
+        headers = {'Content-Type': 'application/json'}
+        data = {
+            "name": "new_host_for_services_0",
+            "services": {
+                "new_service": {
+                    "name": "test_empty_0",
+                    "livestate": {
+                        # No timestamp in the livestate
+                        "state": "OK",
+                        "output": "Output...",
+                        "long_output": "Long output...",
+                        "perf_data": "'counter'=1",
+                    }
+                }
+            }
+        }
+        self.assertEqual(my_module.received_commands, 0)
+        response = session.patch('http://127.0.0.1:8888/host', json=data, headers=headers)
+        self.assertEqual(response.status_code, 200)
+        result = response.json()
+        self.assertEqual(result, {
+            u'_status': u'OK',
+            u'_result': [
+                u'new_host_for_services_0 is alive :)',
+                u"PROCESS_SERVICE_CHECK_RESULT;new_host_for_services_0;test_empty_0;0;Output...|'counter'=1\nLong output...",
+                u"Service 'new_host_for_services_0/test_empty_0' unchanged.",
+                u"Host 'new_host_for_services_0' unchanged."
+            ]
+        })
+        # No errors!
+
+        # Get backend check results - no check result sent to the backend
+        response = requests.get(self.endpoint + '/logcheckresult', auth=self.auth)
+        resp = response.json()
+        rl = resp['_items']
+        self.assertEqual(len(rl), 0)
+
+
+        # Send a service livestate, timestamp in the past
+        headers = {'Content-Type': 'application/json'}
+        now = int(time.time()) - 3600
+        data = {
+            "name": "new_host_for_services_0",
+            "services": {
+                "new_service": {
+                    "name": "test_empty_0",
+                    "livestate": {
+                        # Timestamp in the past
+                        "timestamp": now,
+                        "state": "OK",
+                        "output": "Output...",
+                        "long_output": "Long output...",
+                        "perf_data": "'counter'=1",
+                    }
+                }
+            }
+        }
+        self.assertEqual(my_module.received_commands, 0)
+        response = session.patch('http://127.0.0.1:8888/host', json=data, headers=headers)
+        self.assertEqual(response.status_code, 200)
+        result = response.json()
+        self.assertEqual(result, {
+            u'_status': u'OK',
+            u'_result': [
+                u'new_host_for_services_0 is alive :)',
+                u"[%d] PROCESS_SERVICE_CHECK_RESULT;new_host_for_services_0;test_empty_0;0;Output...|'counter'=1\nLong output..." % now,
+                u"Service 'new_host_for_services_0/test_empty_0' unchanged.",
+                u"Host 'new_host_for_services_0' unchanged."
+            ]
+        })
+        # No errors!
+
+        # Get backend check results - a check result was recorded in the backend
+        response = requests.get(self.endpoint + '/logcheckresult', auth=self.auth)
+        resp = response.json()
+        rl = resp['_items']
+        # A log check result was recorded...
+        self.assertEqual(len(rl), 1)
+        rl = resp['_items'][0]
+        print("LCR: %s" % rl)
+        # ...with the correct timestamp
+        self.assertEqual(rl['host_name'], "new_host_for_services_0")
+        self.assertEqual(rl['service_name'], "test_empty_0")
+        self.assertEqual(rl['last_check'], now)
+
+
+        # Send a service livestate with a timestamp in the past but sooner than the former one
+        now = now + 1800
+        data = {
+            "name": "new_host_for_services_0",
+            "services": {
+                "new_service": {
+                    "name": "test_empty_0",
+                    "livestate": {
+                        # Timestamp in the past
+                        "timestamp": now,
+                        "state": "OK",
+                        "output": "Output...",
+                        "long_output": "Long output...",
+                        "perf_data": "'counter'=1",
+                    }
+                }
+            }
+        }
+        self.assertEqual(my_module.received_commands, 0)
+        response = session.patch('http://127.0.0.1:8888/host', json=data, headers=headers)
+        self.assertEqual(response.status_code, 200)
+        result = response.json()
+        self.assertEqual(result, {
+            u'_status': u'OK',
+            u'_result': [
+                u'new_host_for_services_0 is alive :)',
+                u"[%d] PROCESS_SERVICE_CHECK_RESULT;new_host_for_services_0;test_empty_0;0;Output...|'counter'=1\nLong output..." % now,
+                u"Service 'new_host_for_services_0/test_empty_0' unchanged.",
+                u"Host 'new_host_for_services_0' unchanged."
+            ]
+        })
+        # No errors!
+
+        # Get backend check results - a check result was recorded in the backend
+        response = requests.get(self.endpoint + '/logcheckresult', auth=self.auth)
+        resp = response.json()
+        rl = resp['_items']
+        # A log check result was recorded...
+        self.assertEqual(len(rl), 2)
+        rl = resp['_items'][1]
+        print("LCR: %s" % rl)
+        # ...with the correct timestamp
+        self.assertEqual(rl['host_name'], "new_host_for_services_0")
+        self.assertEqual(rl['service_name'], "test_empty_0")
+        self.assertEqual(rl['last_check'], now)
+
+
+        # Logout
+        response = session.get('http://127.0.0.1:8888/logout')
+        self.assertEqual(response.status_code, 200)
+        result = response.json()
+        self.assertEqual(result['_status'], 'OK')
+        self.assertEqual(result['_result'], 'Logged out')
+
+        self.modulemanager.stop_all()


### PR DESCRIPTION
Closes #61 : allow to record a log check result for an event in the past