### PR TITLE
Fix host parameters update

### DIFF
--- a/alignak_module_ws/ws.py
+++ b/alignak_module_ws/ws.py
@@ -812,7 +812,7 @@ class AlignakWebServices(BaseModule):
                     else:
                         if custom not in customs or customs[custom] != value:
                             update = True
-                            logger.info("Update host variable: %s = %s", prop, value)
+                            logger.info("Update host %s variable: %s = %s", host_name, prop, value)
                             customs[custom] = value
             if update:
                 data['customs'] = customs

--- a/alignak_module_ws/ws.py
+++ b/alignak_module_ws/ws.py
@@ -755,87 +755,27 @@ class AlignakWebServices(BaseModule):
         # Update host check state
         if 'active_checks_enabled' in data:
             if isinstance(data['active_checks_enabled'], bool):
-                update = False
                 if data['active_checks_enabled'] != host['active_checks_enabled']:
-                    update = True
-
-                    logger.info("Host active checks state modified '%s': %s -> %s",
+                    logger.info("Host active checks state is different '%s': %s -> %s",
                                 host_name,
                                 host['active_checks_enabled'], data['active_checks_enabled'])
-                    # Except when an host just got created...
-                    if not host_created:
-                        # todo: perharps this command is not useful
-                        # because the backend is updated...
-                        command_line = 'DISABLE_HOST_CHECK;%s' % host_name
-                        if data['active_checks_enabled']:
-                            command_line = 'ENABLE_HOST_CHECK;%s' % host_name
-                            ws_result['_result'].append(
-                                'Host %s active checks will be enabled.' % host_name)
-                        else:
-                            ws_result['_result'].append(
-                                'Host %s active checks will be disabled.' % host_name)
-
-                        # Add a command to get managed
-                        if self.set_timestamp:
-                            command_line = '[%d] %s' % (time.time(), command_line)
-                        ws_result['_result'].append('Sent external command: %s.' % command_line)
-                        logger.debug("Sending command: %s", command_line)
-                        self.from_q.put(ExternalCommand(command_line))
-                else:
-                    data.pop('active_checks_enabled')
-            else:
-                data.pop('active_checks_enabled')
+            data.pop('active_checks_enabled')
 
         if 'passive_checks_enabled' in data:
             if isinstance(data['passive_checks_enabled'], bool):
-                if update is None:
-                    update = False
                 if data['passive_checks_enabled'] != host['passive_checks_enabled']:
-                    update = True
-
-                    logger.info("Host passive checks state modified '%s': %s -> %s",
+                    logger.info("Host passive checks state is different '%s': %s -> %s",
                                 host_name,
                                 host['passive_checks_enabled'], data['passive_checks_enabled'])
-                    # Except when an host just got created...
-                    if not host_created:
-                        # todo: perharps this command is not useful
-                        # because the backend is updated...
-                        command_line = 'DISABLE_PASSIVE_HOST_CHECKS;%s' % host_name
-                        if data['passive_checks_enabled']:
-                            command_line = 'ENABLE_PASSIVE_HOST_CHECKS;%s' % host_name
-                            ws_result['_result'].append(
-                                'Host %s passive checks will be enabled.' % host_name)
-                        else:
-                            ws_result['_result'].append(
-                                'Host %s passive checks will be disabled.' % host_name)
-
-                        # Add a command to get managed
-                        if self.set_timestamp:
-                            command_line = '[%d] %s' % (time.time(), command_line)
-                        ws_result['_result'].append('Sent external command: %s.' % command_line)
-                        logger.debug("Sending command: %s", command_line)
-                        self.from_q.put(ExternalCommand(command_line))
-                else:
-                    data.pop('passive_checks_enabled')
-            else:
-                data.pop('passive_checks_enabled')
+            data.pop('passive_checks_enabled')
 
         if 'check_freshness' in data:
             if isinstance(data['check_freshness'], bool):
-                if update is None:
-                    update = False
                 if data['check_freshness'] != host['check_freshness']:
-                    update = True
-
-                    logger.info("Host freshness checks state modified '%s': %s -> %s",
+                    logger.info("Host freshness checks state is different '%s': %s -> %s",
                                 host_name,
                                 host['check_freshness'], data['check_freshness'])
-                    # todo: as of Alignak #938, no external command exist
-                    # to enable/disable on an host basis
-                else:
-                    data.pop('check_freshness')
-            else:
-                data.pop('check_freshness')
+            data.pop('check_freshness')
 
         # Update host variables
         if data['variables']:

--- a/test/cfg/backend/alignak-backend-logger.json
+++ b/test/cfg/backend/alignak-backend-logger.json
@@ -1,0 +1,46 @@
+{
+    "version": 1,
+    "disable_existing_loggers": false,
+    "formatters": {
+        "alignak_backend_extra": {
+            "format": "[%(asctime)s] %(levelname)s: [%(name)s] %(clientip)s -- %(method)s -- %(url)s -- %(message)s",
+            "datefmt": "%Y-%m-%d %H:%M:%S"
+        },
+        "alignak_backend": {
+            "format": "[%(asctime)s] %(levelname)s: [%(name)s] %(message)s",
+            "datefmt": "%Y-%m-%d %H:%M:%S"
+        }
+    },
+
+    "handlers": {
+        "console": {
+            "class": "logging.StreamHandler",
+            "level": "DEBUG",
+            "formatter": "alignak_backend",
+            "stream": "ext://sys.stdout"
+        },
+        "alignak_backend": {
+            "class": "logging.handlers.TimedRotatingFileHandler",
+            "level": "DEBUG",
+            "formatter": "alignak_backend",
+            "filename": "/tmp/%(daemon)s.log",
+            "when": "midnight",
+            "interval": 1,
+            "backupCount": 7,
+            "encoding": "utf8"
+        }
+    },
+
+    "loggers": {
+        "eve": {
+            "level": "DEBUG",
+            "handlers": ["alignak_backend"],
+            "propagate": "no"
+        }
+    },
+
+    "root": {
+        "level": "ERROR",
+        "handlers": []
+    }
+}

--- a/test/cfg/backend/settings.json
+++ b/test/cfg/backend/settings.json
@@ -1,0 +1,44 @@
+{
+  "DEBUG": false, /* To run underlying server in debug mode, define true */
+
+  "HOST": "",           /* Backend server listening address, empty = all */
+  "PORT": 5000,         /* Backend server listening port */
+  "SERVER_NAME": null,  /* Backend server listening server name */
+
+  "X_DOMAINS": "*", /* CORS (Cross-Origin Resource Sharing) support. Accept *, empty or a list of domains */
+
+  "PAGINATION_LIMIT": 50,   /* Pagination: maximum value for number of results */
+  "PAGINATION_DEFAULT": 25, /* Pagination: default value for number of results */
+
+  /* Limit number of requests. For example, [300, 900] limit 300 requests every 15 minutes */
+  "RATE_LIMIT_GET": null,     /* Limit number of GET requests */
+  "RATE_LIMIT_POST": null,    /* Limit number of POST requests */
+  "RATE_LIMIT_PATCH": null,   /* Limit number of PATCH requests */
+  "RATE_LIMIT_DELETE": null,  /* Limit number of DELETE requests */
+
+  "MONGO_HOST": "localhost",          /* Address of MongoDB */
+  "MONGO_PORT": 27017,                /* port of MongoDB */
+  "MONGO_DBNAME": "alignak-backend",  /* Name of database in MongoDB */
+  "MONGO_USERNAME": null,             /* Username to access to MongoDB */
+  "MONGO_PASSWORD": null,             /* Password to access to MongoDB */
+
+  "IP_CRON": ["127.0.0.1"],  /* List of IP allowed to use cron routes/endpoint of the backend */
+
+
+  "LOGGER": "alignak-backend-logger.json",  /* Python logger configuration file */
+
+  /* As soon as a Graphite or Influx is existing in the backend, the received metrics are sent
+  to the corresponding TSDB. If the TSDB is not available, metrics are stored internally
+  in the backend.
+  The timeseries scheduler will check periodially if some some metrics are existing in the
+  retention and will send them to the configured TSDB.
+   BE CAREFULL, ACTIVATE THIS ON ONE BACKEND ONLY! */
+  "SCHEDULER_TIMESERIES_ACTIVE": false,
+  /* This scheduler will create / update dashboards in grafana.
+   BE CAREFULL, ACTIVATE IT ONLY ON ONE BACKEND */
+  "SCHEDULER_GRAFANA_ACTIVE": false,
+  /* if 0, disable it, otherwise define the history in minutes.
+   It will keep history each minute.
+   BE CAREFULL, ACTIVATE IT ONLY ON ONE BACKEND */
+  "SCHEDULER_LIVESYNTHESIS_HISTORY": 60
+}

--- a/test/cfg/backend/uwsgi.ini
+++ b/test/cfg/backend/uwsgi.ini
@@ -1,0 +1,41 @@
+[uwsgi]
+http-socket = 0.0.0.0:5000
+
+# Uncomment if you installed from distribution packaging
+# plugin = python
+# Uncomment if you installed from distribution packaging
+# plugin = logfile
+
+# Python module
+module = alignak_backend.app:app
+
+enable-threads = true
+processes = 4
+
+# Log requests activity (disable by default because too verbose)
+# req-logger = file:/usr/local/var/log/alignak-backend/backend-access.log
+# Log information, errors...
+logger = file:/usr/local/var/log/alignak-backend/backend-error.log
+
+# Report memory activity to the stats
+memory-report = true
+
+# Define specific uid/gid if uWSGI started as root
+uid = alignak
+guid = alignak
+
+# Default buffer size for HTTP header is very low (4096)
+buffer-size = 32768
+
+# uWSGI master process: use a master process and store its pid
+master = true
+pidfile = /tmp/alignak-backend.pid
+
+# ---
+# Statistics part
+# Uncomment this line to activate statistics sending to carbon/graphite
+# carbon =  127.0.0.1:2003
+# defaults to uwsgi
+carbon-root = alignak-backend
+# replace dots in hostnames
+carbon-hostname-dots = -

--- a/test/test_module_host.py
+++ b/test/test_module_host.py
@@ -26,6 +26,8 @@ import os
 import time
 import json
 
+import pytest
+
 from freezegun import freeze_time
 
 import shlex
@@ -2049,6 +2051,7 @@ class TestModuleWsHost(AlignakTest):
 
         self.modulemanager.stop_all()
 
+    @pytest.mark.skip("Disabled feature - no more backend host update for passive/active checks")
     def test_module_zzz_host_enable_disable(self):
         """Test the module /host API - enable / disable active / passive checks - manage unchanged
         :return:

--- a/test/test_module_host.py
+++ b/test/test_module_host.py
@@ -2943,9 +2943,6 @@ class TestModuleWsHost(AlignakTest):
             # Do not allow host/service creation
             'allow_host_creation': '0',
             'allow_service_creation': '0',
-            # Do not allow host/service creation
-            'allow_host_creation': '0',
-            'allow_service_creation': '0',
             # Ignore unknown host/service
             'ignore_unknown_host': '1',
             'ignore_unknown_service': '1',


### PR DESCRIPTION
Do not update host main parameters. When an update host is invoked, the module will simply log an information if `passive_checks_enabled`, `active_checks_enabled`, `check_freshess` provided by the client are not the same as the backend ones.

This will avoid some conflicts between the client and the backend ...