### PR TITLE
Discarding the master and slave language

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -50,8 +50,8 @@ source_suffix = '.rst'
 # The encoding of source files.
 #source_encoding = 'utf-8-sig'
 
-# The master toctree document.
-master_doc = 'index'
+# The main toctree document.
+main_doc = 'index'
 
 # General information about the project.
 project = u'Alignak Web Services'
@@ -230,7 +230,7 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-  (master_doc, 'AlignakWebServices.tex', u'Alignak Web Services Documentation',
+  (main_doc, 'AlignakWebServices.tex', u'Alignak Web Services Documentation',
    u'Frédéric MOHIER', 'manual'),
 ]
 
@@ -260,7 +260,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    (master_doc, 'alignakwebservices', u'Alignak Web Services Documentation',
+    (main_doc, 'alignakwebservices', u'Alignak Web Services Documentation',
      [author], 1)
 ]
 
@@ -274,7 +274,7 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-  (master_doc, 'AlignakWebServices', u'Alignak Web Services Documentation',
+  (main_doc, 'AlignakWebServices', u'Alignak Web Services Documentation',
    author, 'AlignakWebServices', 'One line description of project.',
    'Miscellaneous'),
 ]

--- a/test/alignak_test.py
+++ b/test/alignak_test.py
@@ -233,8 +233,8 @@ define host {
 
     def _prepare_configuration(self, copy=True, cfg_folder='/tmp/alignak', daemons_list=None):
         if daemons_list is None:
-            daemons_list = ['arbiter-master', 'scheduler-master', 'broker-master',
-                            'poller-master', 'reactionner-master', 'receiver-master']
+            daemons_list = ['arbiter-main', 'scheduler-main', 'broker-main',
+                            'poller-main', 'reactionner-main', 'receiver-main']
 
         cfg_folder = os.path.join(os.path.dirname(os.path.abspath(__file__)), cfg_folder)
 
@@ -362,7 +362,7 @@ define host {
 
         if getattr(self, 'procs', None):
             for name, proc in list(self.procs.items()):
-                if arbiter_only and name not in ['arbiter-master']:
+                if arbiter_only and name not in ['arbiter-main']:
                     continue
                 if proc.pid == self.my_pid:
                     print("- do not kill myself!")
@@ -445,8 +445,8 @@ define host {
         """
         if daemons_list is None:
             daemons_list = [
-                'scheduler-master', 'broker-master',
-                'poller-master', 'reactionner-master', 'receiver-master'
+                'scheduler-main', 'broker-main',
+                'poller-main', 'reactionner-main', 'receiver-main'
             ]
         # Load and test the configuration
         cfg_folder = os.path.join(os.path.dirname(os.path.abspath(__file__)), cfg_folder)
@@ -460,7 +460,7 @@ define host {
 
         # Clean the former existing pid and log files
         print("Cleaning pid and log files...")
-        for daemon in daemons_list + ['arbiter-master']:
+        for daemon in daemons_list + ['arbiter-main']:
             if os.path.exists('%s/%s.pid' % (self._launch_dir, daemon)):
                 print("- removing pid %s/%s.pid" % (self._launch_dir, daemon))
                 os.remove('%s/%s.pid' % (self._launch_dir, daemon))
@@ -523,8 +523,8 @@ define host {
         #
         print("Launching the daemons...")
         self.procs = {}
-        for name in daemons_list + ['arbiter-master']:
-            if arbiter_only and name not in ['arbiter-master']:
+        for name in daemons_list + ['arbiter-main']:
+            if arbiter_only and name not in ['arbiter-main']:
                 continue
             args = ["../alignak/bin/alignak_%s.py" % name.split('-')[0], "-n", name,
                     "-e", "%s/etc/alignak.ini" % cfg_folder]
@@ -553,8 +553,8 @@ define host {
                         for line in f:
                             print("xxx %s" % line)
 
-                if os.path.exists("%s/log/arbiter-master.log" % cfg_folder):
-                    with open("%s/log/arbiter-master.log" % cfg_folder) as f:
+                if os.path.exists("%s/log/arbiter-main.log" % cfg_folder):
+                    with open("%s/log/arbiter-main.log" % cfg_folder) as f:
                         for line in f:
                             print("... %s" % line)
 
@@ -575,8 +575,8 @@ define host {
         time.sleep(3)
 
         print("Testing pid files and log files...")
-        for name in daemons_list + ['arbiter-master']:
-            if arbiter_only and name not in ['arbiter-master']:
+        for name in daemons_list + ['arbiter-main']:
+            if arbiter_only and name not in ['arbiter-main']:
                 continue
             print("- %s for %s" % ('%s/run/%s.pid' % (run_folder, name), name))
             # Some times pid and log files may not exist ...
@@ -615,7 +615,7 @@ define host {
         ])
         nb_errors = 0
         nb_warnings = 0
-        for daemon in ['arbiter-master'] + daemons_list:
+        for daemon in ['arbiter-main'] + daemons_list:
             log_file = "/%s/log/%s.log" % (run_folder, daemon)
             if not os.path.exists(log_file):
                 log_file = "/%s/run/%s.log" % (run_folder, daemon)
@@ -1104,7 +1104,7 @@ define host {
                 self._receiver_daemon.add(ext_cmd)
                 # self._receiver_daemon.push_external_commands_to_schedulers()
                 # # Our scheduler
-                # self._scheduler = self.schedulers['scheduler-master'].sched
+                # self._scheduler = self.schedulers['scheduler-main'].sched
                 # Give broks to our broker
                 for brok in self._receiver_daemon.broks:
                     print("Brok receiver: %s" % brok)

--- a/test/test_module.py
+++ b/test/test_module.py
@@ -673,7 +673,7 @@ class TestModuleWs(AlignakTest):
         })
 
         # Create a receiver daemon
-        args = {'env_file': '', 'daemon_name': 'receiver-master'}
+        args = {'env_file': '', 'daemon_name': 'receiver-main'}
         self._receiver_daemon = Receiver(**args)
 
         # Create the modules manager for the daemon
@@ -830,7 +830,7 @@ class TestModuleWs(AlignakTest):
         })
 
         # Create a receiver daemon
-        args = {'env_file': '', 'daemon_name': 'receiver-master'}
+        args = {'env_file': '', 'daemon_name': 'receiver-main'}
         self._receiver_daemon = Receiver(**args)
 
         # Create the modules manager for the daemon
@@ -899,7 +899,7 @@ class TestModuleWs(AlignakTest):
         })
 
         # Create a receiver daemon
-        args = {'env_file': '', 'daemon_name': 'receiver-master'}
+        args = {'env_file': '', 'daemon_name': 'receiver-main'}
         self._receiver_daemon = Receiver(**args)
 
         # Create the modules manager for the daemon
@@ -996,7 +996,7 @@ class TestModuleWs(AlignakTest):
         })
 
         # Create a receiver daemon
-        args = {'env_file': '', 'daemon_name': 'receiver-master'}
+        args = {'env_file': '', 'daemon_name': 'receiver-main'}
         self._receiver_daemon = Receiver(**args)
 
         # Create the modules manager for the daemon
@@ -1086,7 +1086,7 @@ class TestModuleWs(AlignakTest):
         })
 
         # Create a receiver daemon
-        args = {'env_file': '', 'daemon_name': 'receiver-master'}
+        args = {'env_file': '', 'daemon_name': 'receiver-main'}
         self._receiver_daemon = Receiver(**args)
 
         # Create the modules manager for the daemon
@@ -1203,7 +1203,7 @@ class TestModuleWs(AlignakTest):
         })
 
         # Create a receiver daemon
-        args = {'env_file': '', 'daemon_name': 'receiver-master'}
+        args = {'env_file': '', 'daemon_name': 'receiver-main'}
         self._receiver_daemon = Receiver(**args)
 
         # Create the modules manager for the daemon

--- a/test/test_module_command.py
+++ b/test/test_module_command.py
@@ -183,7 +183,7 @@ class TestModuleWsCommand(AlignakTest):
         })
 
         # Create a receiver daemon
-        args = {'env_file': '', 'daemon_name': 'receiver-master'}
+        args = {'env_file': '', 'daemon_name': 'receiver-main'}
         self._receiver_daemon = Receiver(**args)
 
         # Create the modules manager for the daemon
@@ -403,7 +403,7 @@ class TestModuleWsCommand(AlignakTest):
         })
 
         # Create a receiver daemon
-        args = {'env_file': '', 'daemon_name': 'receiver-master'}
+        args = {'env_file': '', 'daemon_name': 'receiver-main'}
         self._receiver_daemon = Receiver(**args)
 
         # Create the modules manager for the daemon

--- a/test/test_module_event.py
+++ b/test/test_module_event.py
@@ -185,7 +185,7 @@ class TestModuleWsEvent(AlignakTest):
         })
 
         # Create a receiver daemon
-        args = {'env_file': '', 'daemon_name': 'receiver-master'}
+        args = {'env_file': '', 'daemon_name': 'receiver-main'}
         self._receiver_daemon = Receiver(**args)
 
         # Create the modules manager for the daemon
@@ -389,7 +389,7 @@ class TestModuleWsEvent(AlignakTest):
         })
 
         # Create a receiver daemon
-        args = {'env_file': '', 'daemon_name': 'receiver-master'}
+        args = {'env_file': '', 'daemon_name': 'receiver-main'}
         self._receiver_daemon = Receiver(**args)
 
         # Create the modules manager for the daemon

--- a/test/test_module_history.py
+++ b/test/test_module_history.py
@@ -266,7 +266,7 @@ class TestModuleWsHistory(AlignakTest):
         })
 
         # Create a receiver daemon
-        args = {'env_file': '', 'daemon_name': 'receiver-master'}
+        args = {'env_file': '', 'daemon_name': 'receiver-main'}
         self._receiver_daemon = Receiver(**args)
 
         # Create the modules manager for the daemon

--- a/test/test_module_host.py
+++ b/test/test_module_host.py
@@ -203,7 +203,7 @@ class TestModuleWsHost(AlignakTest):
         })
 
         # Create a receiver daemon
-        args = {'env_file': '', 'daemon_name': 'receiver-master'}
+        args = {'env_file': '', 'daemon_name': 'receiver-main'}
         self._receiver_daemon = Receiver(**args)
 
         # Create the modules manager for the daemon
@@ -679,7 +679,7 @@ class TestModuleWsHost(AlignakTest):
         })
 
         # Create a receiver daemon
-        args = {'env_file': '', 'daemon_name': 'receiver-master'}
+        args = {'env_file': '', 'daemon_name': 'receiver-main'}
         self._receiver_daemon = Receiver(**args)
 
         # Create the modules manager for the daemon
@@ -911,7 +911,7 @@ class TestModuleWsHost(AlignakTest):
         print("Module...")
 
         # Create a receiver daemon
-        args = {'env_file': '', 'daemon_name': 'receiver-master'}
+        args = {'env_file': '', 'daemon_name': 'receiver-main'}
         self._receiver_daemon = Receiver(**args)
         print("Daemon...")
 
@@ -1476,7 +1476,7 @@ class TestModuleWsHost(AlignakTest):
         })
 
         # Create a receiver daemon
-        args = {'env_file': '', 'daemon_name': 'receiver-master'}
+        args = {'env_file': '', 'daemon_name': 'receiver-main'}
         self._receiver_daemon = Receiver(**args)
 
         # Create the modules manager for the daemon
@@ -1845,7 +1845,7 @@ class TestModuleWsHost(AlignakTest):
         mod = Module(mod_conf)
 
         # Create a receiver daemon
-        args = {'env_file': '', 'daemon_name': 'receiver-master'}
+        args = {'env_file': '', 'daemon_name': 'receiver-main'}
         self._receiver_daemon = Receiver(**args)
 
         # Create the modules manager for the daemon
@@ -1968,7 +1968,7 @@ class TestModuleWsHost(AlignakTest):
         })
 
         # Create a receiver daemon
-        args = {'env_file': '', 'daemon_name': 'receiver-master'}
+        args = {'env_file': '', 'daemon_name': 'receiver-main'}
         self._receiver_daemon = Receiver(**args)
 
         # Create the modules manager for the daemon
@@ -2362,7 +2362,7 @@ class TestModuleWsHost(AlignakTest):
         })
 
         # Create a receiver daemon
-        args = {'env_file': '', 'daemon_name': 'receiver-master'}
+        args = {'env_file': '', 'daemon_name': 'receiver-main'}
         self._receiver_daemon = Receiver(**args)
 
         # Create the modules manager for the daemon
@@ -2821,7 +2821,7 @@ class TestModuleWsHost(AlignakTest):
         })
 
         # Create a receiver daemon
-        args = {'env_file': '', 'daemon_name': 'receiver-master'}
+        args = {'env_file': '', 'daemon_name': 'receiver-main'}
         self._receiver_daemon = Receiver(**args)
 
         # Create the modules manager for the daemon
@@ -2991,7 +2991,7 @@ class TestModuleWsHost(AlignakTest):
             }
         })
         # Response always contains host backend data!
-        # Host is data-slave for the host configuration !
+        # Host is data-subordinate for the host configuration !
 
         # Logout
         response = session.get(self.ws_endpoint + '/logout')
@@ -3037,7 +3037,7 @@ class TestModuleWsHost(AlignakTest):
         })
 
         # Create a receiver daemon
-        args = {'env_file': '', 'daemon_name': 'receiver-master'}
+        args = {'env_file': '', 'daemon_name': 'receiver-main'}
         self._receiver_daemon = Receiver(**args)
 
         # Create the modules manager for the daemon
@@ -3278,7 +3278,7 @@ class TestModuleWsHost(AlignakTest):
         })
 
         # Create a receiver daemon
-        args = {'env_file': '', 'daemon_name': 'receiver-master'}
+        args = {'env_file': '', 'daemon_name': 'receiver-main'}
         self._receiver_daemon = Receiver(**args)
 
         # Create the modules manager for the daemon
@@ -3463,7 +3463,7 @@ class TestModuleWsHost(AlignakTest):
         })
 
         # Create a receiver daemon
-        args = {'env_file': '', 'daemon_name': 'receiver-master'}
+        args = {'env_file': '', 'daemon_name': 'receiver-main'}
         self._receiver_daemon = Receiver(**args)
 
         # Create the modules manager for the daemon

--- a/test/test_module_host_creation.py
+++ b/test/test_module_host_creation.py
@@ -239,7 +239,7 @@ class TestModuleWsHostServiceCreation(AlignakTest):
         })
 
         # Create a receiver daemon
-        args = {'env_file': '', 'daemon_name': 'receiver-master'}
+        args = {'env_file': '', 'daemon_name': 'receiver-main'}
         self._receiver_daemon = Receiver(**args)
 
         # Create the modules manager for the daemon
@@ -557,7 +557,7 @@ class TestModuleWsHostServiceCreation(AlignakTest):
         })
 
         # Create a receiver daemon
-        args = {'env_file': '', 'daemon_name': 'receiver-master'}
+        args = {'env_file': '', 'daemon_name': 'receiver-main'}
         self._receiver_daemon = Receiver(**args)
 
         # Create the modules manager for the daemon
@@ -902,7 +902,7 @@ class TestModuleWsHostServiceCreation(AlignakTest):
         })
 
         # Create a receiver daemon
-        args = {'env_file': '', 'daemon_name': 'receiver-master'}
+        args = {'env_file': '', 'daemon_name': 'receiver-main'}
         self._receiver_daemon = Receiver(**args)
 
         # Create the modules manager for the daemon

--- a/test/test_module_host_get.py
+++ b/test/test_module_host_get.py
@@ -184,7 +184,7 @@ class TestModuleWsHostGet(AlignakTest):
         })
 
         # Create a receiver daemon
-        args = {'env_file': '', 'daemon_name': 'receiver-master'}
+        args = {'env_file': '', 'daemon_name': 'receiver-main'}
         self._receiver_daemon = Receiver(**args)
 
         # Create the modules manager for the daemon

--- a/test/test_module_host_livestate.py
+++ b/test/test_module_host_livestate.py
@@ -183,9 +183,9 @@ class TestModuleWsHostLivestate(AlignakTest):
 
         """
         When module is really loaded in Alignak:
-        [2018-03-31 11:43:42] DEBUG: [receiver-master.alignak.module.web-services] inner properties: {'init_try': 0, 'illegal_char': <_sre.SRE_Pattern object at 0x808e03d50>, 'phases': ['running'], 'is_external': True, 'myconf': <'Module' u'web-services', module: u'alignak_module_ws', type(s): u'web-services' />, 'to_q': None, 'process': None, 'from_q': None, 'interrupted': False, 'loaded_into': 'unknown', 'props': {'daemons': ['receiver'], 'phases': ['running'], 'type': 'web-services', 'external': True}, 'kill_delay': 60, 'module_monitoring_period': 10, 'module_monitoring': False, 'properties': {'daemons': ['receiver'], 'phases': ['running'], 'type': 'web-services', 'external': True}, 'name': u'web-services'}
-        [2018-03-31 11:43:42] DEBUG: [receiver-master.alignak.module.web-services] received configuration: {'enable_problem_impacts_states_change': u'1', 'log_notifications': u'1', 'statsd_prefix': u'alignak-fdj.modules', 'statsd_host': u'localhost', 'daemons_initial_port': u'7800', 'log_initial_states': u'0', 'group': u'alignak', 'uuid': u'f0b02b5dfa7a4e1484166a4ef9b1cad3', 'alignak_polling_period': u'60', 'notification_timeout': u'30', 'execute_service_checks': u'1', 'disable_old_nagios_parameters_whining': u'1', 'log_external_commands': u'1', 'tick_update_retention': u'1800', 'password': u'ipm-France2017', 'idontcareaboutsecurity': u'0', 'python_name': u'alignak_module_ws', 'daemon': u'unset', 'tick_update_program_status': u'10', 'name': u'web-services', 'statsd_enabled': False, 'alignak_host': u'alignak1', 'alignak_launched': u'1', 'tick_clean_queues': u'10', 'daemons_stop_timeout': u'10', 'old_properties': {}, 'max_plugins_output_length': u'65536', 'downtimes': {}, 'tags': set([]), 'log_event_handlers': u'1', 'enable_notifications': u'1', 'do_replace': u'1', 'definition_order': 100, 'alignak_backend': u'http://alignak_backend1:5000', 'logger_configuration': u'/usr/local//etc/alignak/alignak-logger.json', 'use': [], 'check_host_freshness': u'1', 'spare': u'0', 'log_host_retries': u'1', 'properties': {'daemons': ['receiver'], 'phases': ['running'], 'type': 'web-services', 'external': True}, 'set_timestamp': u'1', 'max_service_check_spread': u'5', 'execute_host_checks': u'1', 'host_freshness_check_interval': u'1200', 'retention_update_interval': u'60', 'log_snapshots': u'1', 'accept_passive_service_checks': u'1', 'service_freshness_check_interval': u'1800', 'module_alias': u'web-services', 'module_types': [u''], 'alignak_name': u'alignak-fdj', 'max_queue_size': u'0', 'alignak_port': u'7770', 'type': u'web-services', 'authorization': u'1', 'logdir': u'/usr/local//var/log/alignak', 'username': u'admin', 'feedback_host': u'active_checks_enabled,check_interval,retry_interval,passive_checks_enabled,freshness_threshold', 'conf_is_correct': True, 'log_passive_checks': u'0', 'etcdir': u'/usr/local//etc/alignak', 'check_service_freshness': u'0', 'daemons_check_period': u'5', 'configuration_warnings': [], 'imported_from': 'unknown', 'max_host_check_spread': u'5', 'config_name': u'Alignak FdJ configuration', 'statsd_port': 8125, 'accept_passive_host_checks': u'1', 'log_active_checks': u'0', 'allow_host_creation': u'1', 'no_event_handlers_during_downtimes': u'1', 'log_service_retries': u'1', 'accept_passive_unknown_check_results': u'1', 'alignak_backend_timeshift': u'5', 'allow_service_creation': u'0', 'use_ssl': u'0', 'daemons_log_folder': u'/usr/local//var/log/alignak', 'realm': u'All', 'realm_case': u'upper', 'polling_interval': u'5', 'enable_environment_macros': u'0', 'workdir': u'/usr/local//var/run/alignak', 'log_flappings': u'1', 'customs': {}, 'user': u'alignak', 'log_level': u'DEBUG', 'configuration_errors': [], 'register': True, 'alias': u'web-services'}
-        [2018-03-31 11:43:42] DEBUG: [receiver-master.alignak.module.web-services] loaded into: unknown
+        [2018-03-31 11:43:42] DEBUG: [receiver-main.alignak.module.web-services] inner properties: {'init_try': 0, 'illegal_char': <_sre.SRE_Pattern object at 0x808e03d50>, 'phases': ['running'], 'is_external': True, 'myconf': <'Module' u'web-services', module: u'alignak_module_ws', type(s): u'web-services' />, 'to_q': None, 'process': None, 'from_q': None, 'interrupted': False, 'loaded_into': 'unknown', 'props': {'daemons': ['receiver'], 'phases': ['running'], 'type': 'web-services', 'external': True}, 'kill_delay': 60, 'module_monitoring_period': 10, 'module_monitoring': False, 'properties': {'daemons': ['receiver'], 'phases': ['running'], 'type': 'web-services', 'external': True}, 'name': u'web-services'}
+        [2018-03-31 11:43:42] DEBUG: [receiver-main.alignak.module.web-services] received configuration: {'enable_problem_impacts_states_change': u'1', 'log_notifications': u'1', 'statsd_prefix': u'alignak-fdj.modules', 'statsd_host': u'localhost', 'daemons_initial_port': u'7800', 'log_initial_states': u'0', 'group': u'alignak', 'uuid': u'f0b02b5dfa7a4e1484166a4ef9b1cad3', 'alignak_polling_period': u'60', 'notification_timeout': u'30', 'execute_service_checks': u'1', 'disable_old_nagios_parameters_whining': u'1', 'log_external_commands': u'1', 'tick_update_retention': u'1800', 'password': u'ipm-France2017', 'idontcareaboutsecurity': u'0', 'python_name': u'alignak_module_ws', 'daemon': u'unset', 'tick_update_program_status': u'10', 'name': u'web-services', 'statsd_enabled': False, 'alignak_host': u'alignak1', 'alignak_launched': u'1', 'tick_clean_queues': u'10', 'daemons_stop_timeout': u'10', 'old_properties': {}, 'max_plugins_output_length': u'65536', 'downtimes': {}, 'tags': set([]), 'log_event_handlers': u'1', 'enable_notifications': u'1', 'do_replace': u'1', 'definition_order': 100, 'alignak_backend': u'http://alignak_backend1:5000', 'logger_configuration': u'/usr/local//etc/alignak/alignak-logger.json', 'use': [], 'check_host_freshness': u'1', 'spare': u'0', 'log_host_retries': u'1', 'properties': {'daemons': ['receiver'], 'phases': ['running'], 'type': 'web-services', 'external': True}, 'set_timestamp': u'1', 'max_service_check_spread': u'5', 'execute_host_checks': u'1', 'host_freshness_check_interval': u'1200', 'retention_update_interval': u'60', 'log_snapshots': u'1', 'accept_passive_service_checks': u'1', 'service_freshness_check_interval': u'1800', 'module_alias': u'web-services', 'module_types': [u''], 'alignak_name': u'alignak-fdj', 'max_queue_size': u'0', 'alignak_port': u'7770', 'type': u'web-services', 'authorization': u'1', 'logdir': u'/usr/local//var/log/alignak', 'username': u'admin', 'feedback_host': u'active_checks_enabled,check_interval,retry_interval,passive_checks_enabled,freshness_threshold', 'conf_is_correct': True, 'log_passive_checks': u'0', 'etcdir': u'/usr/local//etc/alignak', 'check_service_freshness': u'0', 'daemons_check_period': u'5', 'configuration_warnings': [], 'imported_from': 'unknown', 'max_host_check_spread': u'5', 'config_name': u'Alignak FdJ configuration', 'statsd_port': 8125, 'accept_passive_host_checks': u'1', 'log_active_checks': u'0', 'allow_host_creation': u'1', 'no_event_handlers_during_downtimes': u'1', 'log_service_retries': u'1', 'accept_passive_unknown_check_results': u'1', 'alignak_backend_timeshift': u'5', 'allow_service_creation': u'0', 'use_ssl': u'0', 'daemons_log_folder': u'/usr/local//var/log/alignak', 'realm': u'All', 'realm_case': u'upper', 'polling_interval': u'5', 'enable_environment_macros': u'0', 'workdir': u'/usr/local//var/run/alignak', 'log_flappings': u'1', 'customs': {}, 'user': u'alignak', 'log_level': u'DEBUG', 'configuration_errors': [], 'register': True, 'alias': u'web-services'}
+        [2018-03-31 11:43:42] DEBUG: [receiver-main.alignak.module.web-services] loaded into: unknown
 
         """
         # Create an Alignak module
@@ -224,7 +224,7 @@ class TestModuleWsHostLivestate(AlignakTest):
         })
 
         # Create a receiver daemon
-        args = {'env_file': '', 'daemon_name': 'receiver-master'}
+        args = {'env_file': '', 'daemon_name': 'receiver-main'}
         self._receiver_daemon = Receiver(**args)
 
         # Create the modules manager for the daemon
@@ -477,7 +477,7 @@ class TestModuleWsHostLivestate(AlignakTest):
         })
 
         # Create a receiver daemon
-        args = {'env_file': '', 'daemon_name': 'receiver-master'}
+        args = {'env_file': '', 'daemon_name': 'receiver-main'}
         self._receiver_daemon = Receiver(**args)
 
         # Create the modules manager for the daemon
@@ -691,7 +691,7 @@ class TestModuleWsHostLivestate(AlignakTest):
         })
 
         # Create a receiver daemon
-        args = {'env_file': './cfg/default/alignak.ini', 'daemon_name': 'receiver-master'}
+        args = {'env_file': './cfg/default/alignak.ini', 'daemon_name': 'receiver-main'}
         self._receiver_daemon = Receiver(**args)
         # Create the modules manager for the daemon
         self.modulemanager = ModulesManager(self._receiver_daemon)
@@ -910,7 +910,7 @@ class TestModuleWsHostLivestate(AlignakTest):
         })
 
         # Create a receiver daemon
-        args = {'env_file': '', 'daemon_name': 'receiver-master'}
+        args = {'env_file': '', 'daemon_name': 'receiver-main'}
         self._receiver_daemon = Receiver(**args)
 
         # Create the modules manager for the daemon
@@ -1252,7 +1252,7 @@ class TestModuleWsHostLivestate(AlignakTest):
         })
 
         # Create a receiver daemon
-        args = {'env_file': '', 'daemon_name': 'receiver-master'}
+        args = {'env_file': '', 'daemon_name': 'receiver-main'}
         self._receiver_daemon = Receiver(**args)
 
         # Create the modules manager for the daemon

--- a/test/test_module_hostgroup_get.py
+++ b/test/test_module_hostgroup_get.py
@@ -190,7 +190,7 @@ class TestModuleWsHostgroup(AlignakTest):
         })
 
         # Create a receiver daemon
-        args = {'env_file': '', 'daemon_name': 'receiver-master'}
+        args = {'env_file': '', 'daemon_name': 'receiver-main'}
         self._receiver_daemon = Receiver(**args)
 
         # Create the modules manager for a daemon type

--- a/test/test_module_no_backend.py
+++ b/test/test_module_no_backend.py
@@ -122,7 +122,7 @@ class TestModuleNoBackend(AlignakTest):
         })
 
         # Create a receiver daemon
-        args = {'env_file': '', 'daemon_name': 'receiver-master'}
+        args = {'env_file': '', 'daemon_name': 'receiver-main'}
         self._receiver_daemon = Receiver(**args)
 
         # Create the modules manager for the daemon


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.